### PR TITLE
Add map-like get(Tag) to RtMessage

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -1,3 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[macro_use]
 extern crate clap;
 extern crate roughenough;

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -29,11 +29,12 @@ use chrono::TimeZone;
 use chrono::offset::Utc;
 
 use std::iter::Iterator;
-use std::collections::HashMap;
 use std::net::{UdpSocket, ToSocketAddrs};
 
-use roughenough::{RtMessage, Tag, VERSION, TREE_NODE_TWEAK, TREE_LEAF_TWEAK, CERTIFICATE_CONTEXT, SIGNED_RESPONSE_CONTEXT};
+use roughenough::{RtMessage, Tag};
+use roughenough::{VERSION, TREE_NODE_TWEAK, TREE_LEAF_TWEAK, CERTIFICATE_CONTEXT, SIGNED_RESPONSE_CONTEXT};
 use roughenough::sign::Verifier;
+
 use clap::{Arg, App};
 
 fn create_nonce() -> [u8; 64] {
@@ -58,23 +59,21 @@ fn receive_response(sock: &mut UdpSocket) -> RtMessage {
     RtMessage::from_bytes(&buf[0..resp_len]).unwrap()
 }
 
-
 struct ResponseHandler {
     pub_key: Option<Vec<u8>>,
-    msg: HashMap<Tag, Vec<u8>>,
-    srep: HashMap<Tag, Vec<u8>>,
-    cert: HashMap<Tag, Vec<u8>>,
-    dele: HashMap<Tag, Vec<u8>>,
+    msg: RtMessage,
+    srep: RtMessage,
+    cert: RtMessage,
+    dele: RtMessage,
     nonce: [u8; 64]
 }
 
 impl ResponseHandler {
     pub fn new(pub_key: Option<Vec<u8>>, response: RtMessage, nonce: [u8; 64]) -> ResponseHandler {
-        let msg = response.into_hash_map();
-        let srep = RtMessage::from_bytes(&msg[&Tag::SREP]).unwrap().into_hash_map();
-        let cert = RtMessage::from_bytes(&msg[&Tag::CERT]).unwrap().into_hash_map();
-
-        let dele = RtMessage::from_bytes(&cert[&Tag::DELE]).unwrap().into_hash_map();
+        let msg = response.clone();
+        let srep = RtMessage::from_bytes(response.get(Tag::SREP).unwrap()).unwrap();
+        let cert = RtMessage::from_bytes(response.get(Tag::CERT).unwrap()).unwrap();
+        let dele = RtMessage::from_bytes(cert.get(Tag::DELE).unwrap()).unwrap();
 
         ResponseHandler {
             pub_key,
@@ -87,8 +86,8 @@ impl ResponseHandler {
     }
 
     pub fn extract_time(&self) -> (u64, u32) {
-        let midpoint = self.srep[&Tag::MIDP].as_slice().read_u64::<LittleEndian>().unwrap();
-        let radius = self.srep[&Tag::RADI].as_slice().read_u32::<LittleEndian>().unwrap();
+        let midpoint = self.srep.get(Tag::MIDP).unwrap().read_u64::<LittleEndian>().unwrap();
+        let radius = self.srep.get(Tag::RADI).unwrap().read_u32::<LittleEndian>().unwrap();
 
         if self.pub_key.is_some() {
             self.validate_dele();
@@ -102,24 +101,27 @@ impl ResponseHandler {
 
     fn validate_dele(&self) {
         let mut full_cert = Vec::from(CERTIFICATE_CONTEXT.as_bytes());
-        full_cert.extend(&self.cert[&Tag::DELE]);
+        full_cert.extend(self.cert.get(Tag::DELE).unwrap());
 
-        assert!(self.validate_sig(self.pub_key.as_ref().unwrap(), &self.cert[&Tag::SIG], &full_cert),
-                "Invalid signature on DELE tag!");
+        let pub_key = self.pub_key.as_ref().unwrap();
+        let sig = self.cert.get(Tag::SIG).unwrap();
+
+        assert!(self.validate_sig(pub_key, sig, &full_cert), "Invalid signature on DELE tag!");
     }
 
     fn validate_srep(&self) {
         let mut full_srep = Vec::from(SIGNED_RESPONSE_CONTEXT.as_bytes());
-        full_srep.extend(&self.msg[&Tag::SREP]);
+        full_srep.extend(self.msg.get(Tag::SREP).unwrap());
 
-        assert!(self.validate_sig(&self.dele[&Tag::PUBK], &self.msg[&Tag::SIG], &full_srep),
-                "Invalid signature on SREP tag!");
+        let pub_key = self.dele.get(Tag::PUBK).unwrap();
+        let sig = self.msg.get(Tag::SIG).unwrap();
+
+        assert!(self.validate_sig(pub_key, sig, &full_srep), "Invalid signature on SREP tag!");
     }
 
     fn validate_merkle(&self) {
-        let srep = RtMessage::from_bytes(&self.msg[&Tag::SREP]).unwrap().into_hash_map();
-        let mut index = self.msg[&Tag::INDX].as_slice().read_u32::<LittleEndian>().unwrap();
-        let paths = &self.msg[&Tag::PATH];
+        let mut index = self.msg.get(Tag::INDX).unwrap().read_u32::<LittleEndian>().unwrap();
+        let paths = self.msg.get(Tag::PATH).unwrap();
 
         let mut hash = sha_512(TREE_LEAF_TWEAK, &self.nonce);
 
@@ -143,13 +145,13 @@ impl ResponseHandler {
             index >>= 1;
         }
 
-        assert_eq!(hash, srep[&Tag::ROOT], "Nonce not in merkle tree!");
+        assert_eq!(hash, self.srep.get(Tag::ROOT).unwrap(), "Nonce not in merkle tree!");
 
     }
 
     fn validate_midpoint(&self, midpoint: u64) {
-        let mint = self.dele[&Tag::MINT].as_slice().read_u64::<LittleEndian>().unwrap();
-        let maxt = self.dele[&Tag::MAXT].as_slice().read_u64::<LittleEndian>().unwrap();
+        let mint = self.dele.get(Tag::MINT).unwrap().read_u64::<LittleEndian>().unwrap();
+        let maxt = self.dele.get(Tag::MAXT).unwrap().read_u64::<LittleEndian>().unwrap();
 
         assert!(midpoint >= mint, "Response midpoint {} lies before delegation span ({}, {})");
         assert!(midpoint <= maxt, "Response midpoint {} lies after delegation span ({}, {})");
@@ -234,6 +236,6 @@ fn main() {
         let spec = Utc.timestamp(seconds as i64, ((midpoint - (seconds * 10_u64.pow(6))) * 10_u64.pow(3)) as u32);
         let out = spec.format(time_format).to_string();
 
-        println!("Recieved time from server: midpoint={:?}, radius={:?}", out, radius);
+        println!("Received time from server: midpoint={:?}, radius={:?}", out, radius);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,7 @@ pub enum Error {
     /// The associated tag was added to an `RtMessage` in non-increasing order.
     TagNotStrictlyIncreasing(Tag),
 
+    /// Associated bytes do not correspond to a valid `Tag`
     InvalidTag(Box<[u8]>),
 
     /// Encoding failed. The associated `std::io::Error` should provide more information.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,17 @@
 //! # Protocol
 //!
 //! Roughtime messages are represetned by [`RtMessage`](struct.RtMessage.html) which 
-//! implements the mapping of Roughtime `u32` [`tags`](enum.Tag.html) to byte-strings. 
+//! implements the mapping of Roughtime `u32` [`tags`](enum.Tag.html) to byte-strings.
+//!
+//! # Client
+//!
+//! A Roughtime client can be found in `src/bin/client.rs`. To run the client:
+//!
+//! ```bash
+//! $ cargo run --release --bin client roughtime.int08h.com 2002
+//! ```
+//!
+//! Consult the client's `--help` output for all runtime options.
 //!
 //! # Server
 //!

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -14,8 +14,8 @@
 
 use error::Error;
 
-/// An unsigned 32-bit value (key) that maps to a byte-string (value).
-#[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Clone)]
+/// A Roughtime "tag" is an unsigned 32-bit key that maps to a byte-string (value).
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Clone)]
 pub enum Tag {
     // Enforcement of the "tags in strictly increasing order" rule is done using the
     // little-endian encoding of the ASCII tag value; e.g. 'SIG\x00' is 0x00474953 and
@@ -59,6 +59,8 @@ impl Tag {
         }
     }
 
+    /// Returns the tag corresponding to the on-the-wire bytes, or
+    /// [`Error::InvalidTag`](enum.Error.html) if they do not represent a valid tag.
     pub fn from_wire(bytes: &[u8]) -> Result<Self, Error> {
         match bytes {
             b"CERT" => Ok(Tag::CERT),


### PR DESCRIPTION
Replace `HashMap` usage in client by implementing map-like lookup on `RtMessage` directly. 

New method takes advantage of already sorted keys (the message tags) for efficient log2(n) lookup.

@Aaron1011 PTAL, this was what I was referring to in [my comment](https://github.com/int08h/roughenough/pull/1#discussion_r173638547) on your PR 