### PR TITLE
Test roughenough on nightly rust on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: rust
 rust:
   - stable
+  - nightly
+
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true


### PR DESCRIPTION
The nightly job is marked as an allowed failure - combined with
the fast_finish option, this ensures that nightly failures won't
slow down or break the build.