### PR TITLE
Land validation and error handling improvements from roughenough-fuzz

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ Roughtime features not implemented by the server:
 
 Other notes:
 
-* Error-handling needs a closer examination to verify the `unwrap()`'s and `expect()`'s present
-  in the request handling path are for truly exceptional conditions.
 * Per-request heap allocations could probably be reduced: a few `Vec`'s could be replaced by 
   lifetime scoped slices.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,12 @@ pub enum Error {
     /// The associated byte sequence does not correspond to a valid Roughtime tag.
     InvalidTag(Box<[u8]>),
 
+    /// Invalid number of tags specified
+    InvalidNumTags(u32),
+
+    /// Tag value length exceeds length of source bytes
+    InvalidValueLength(Tag, u32),
+
     /// Encoding failed. The associated `std::io::Error` should provide more information.
     EncodingFailure(std::io::Error),
 
@@ -36,9 +42,6 @@ pub enum Error {
 
     /// Offset is outside of valid message range
     InvalidOffsetValue(u32),
-
-    /// Invalid number of tags specified 
-    InvalidNumTags(u32),
 
     /// Could not convert bytes to message because bytes were too short
     MessageTooShort,

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,8 +37,8 @@ pub enum Error {
     /// Request was less than 1024 bytes
     RequestTooShort,
 
-    /// Offset was not 32-bit aligned 
-    InvalidOffsetAlignment(u32),
+    /// Offset was not 32-bit aligned
+    InvalidAlignment(u32),
 
     /// Offset is outside of valid message range
     InvalidOffsetValue(u32),

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,9 @@ pub enum Error {
     /// Request was less than 1024 bytes
     RequestTooShort,
 
+    /// Offset within message was not 32-bit aligned 
+    InvalidOffsetAlignment(u32),
+
     /// Otherwise invalid request
     InvalidRequest,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! # Protocol
 //!
-//! Roughtime messages are represetned by [`RtMessage`](struct.RtMessage.html) which
+//! Roughtime messages are represented by [`RtMessage`](struct.RtMessage.html) which
 //! implements the mapping of Roughtime `u32` [`tags`](enum.Tag.html) to byte-strings.
 //!
 //! # Client

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//!
+//! Merkle Tree implementation using SHA-512 and the Roughtime leaf and node tweak values.
+//!
+
 extern crate ring;
 
 use super::{HASH_LENGTH, TREE_LEAF_TWEAK, TREE_NODE_TWEAK};
@@ -20,11 +24,18 @@ use self::ring::digest;
 type Data = Vec<u8>;
 type Hash = Data;
 
+///
+/// Merkle Tree implementation using SHA-512 and the Roughtime leaf and node tweak values.
+///
 pub struct MerkleTree {
     levels: Vec<Vec<Data>>,
 }
 
 impl MerkleTree {
+
+    ///
+    /// Create a new empty Merkle Tree
+    ///
     pub fn new() -> MerkleTree {
         MerkleTree {
             levels: vec![vec![]],

--- a/src/message.rs
+++ b/src/message.rs
@@ -184,14 +184,17 @@ impl RtMessage {
         self.tags.len() as u32
     }
 
+    /// Returns a slice of the tags in the message
     pub fn tags(&self) -> &[Tag] {
         &self.tags
     }
 
+    /// Returns a slice of the values in the message
     pub fn values(&self) -> &[Vec<u8>] {
         &self.values
     }
 
+    /// Converts the message into a `HashMap` mapping each tag to its value
     pub fn into_hash_map(self) -> HashMap<Tag, Vec<u8>> {
         self.tags.into_iter().zip(self.values.into_iter()).collect()
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -43,6 +43,12 @@ impl RtMessage {
         }
     }
 
+    /// Construct a new RtMessage from the on-the-wire representation in `bytes`
+    ///
+    /// ## Arguments
+    ///
+    /// * `bytes` - On-the-wire representation
+    ///
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         let mut msg = Cursor::new(bytes);
 
@@ -88,6 +94,7 @@ impl RtMessage {
         // All offsets are relative to the end of the header,
         // which is our current position
         let header_end = msg.position() as usize;
+
         // Compute the end of the last value,
         // as an offset from the end of the header
         let msg_end = bytes.len() - header_end;

--- a/src/message.rs
+++ b/src/message.rs
@@ -70,6 +70,10 @@ impl RtMessage {
 
     /// Internal function to create a single tag message
     fn single_tag_message(bytes: &[u8], msg: &mut Cursor<&[u8]>) -> Result<Self, Error> {
+        if bytes.len() < 8 {
+            return Err(Error::MessageTooShort);
+        }
+
         let pos = msg.position() as usize;
         msg.set_position((pos + 4) as u64);
 
@@ -80,7 +84,7 @@ impl RtMessage {
         let mut rt_msg = RtMessage::new(1);
         rt_msg.add_field(tag, &value)?;
 
-        return Ok(rt_msg);
+        Ok(rt_msg)
     }
 
     /// Internal function to create a multiple tag message

--- a/src/message.rs
+++ b/src/message.rs
@@ -67,7 +67,7 @@ impl RtMessage {
         for _ in 0..num_tags - 1 {
             let offset = msg.read_u32::<LittleEndian>()?;
             if offset % 4 != 0 {
-                panic!("Invalid offset {:?} in message {:?}", offset, bytes);
+                return Err(Error::InvalidOffsetAlignment(offset));
             }
             offsets.push(offset as usize);
         }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -59,6 +59,8 @@ impl Tag {
         }
     }
 
+    /// Return the `Tag` corresponding to the on-the-wire representation in `bytes` or an
+    /// `Error::InvalidTag` if `bytes` do not correspond to a valid tag.
     pub fn from_wire(bytes: &[u8]) -> Result<Self, Error> {
         match bytes {
             b"CERT" => Ok(Tag::CERT),


### PR DESCRIPTION
This PR integrates error handling and robustness improvements from [AFL](http://lcamtuf.coredump.cx/afl/) fuzzing via the sister repo [roughenough-fuzz](https://github.com/int08h/roughenough-fuzz).

