### PR TITLE
Improved Client Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,18 @@ $ cp target/release/roughenough-client /usr/local/bin
 ### Using the Client to Query a Roughtime Server 
 
 ```bash
-$ target/release/roughenough-client roughtime.int08h.com 2002
+$ target/release/roughenough-client -v roughtime.int08h.com 2002
 Requesting time from: "roughtime.int08h.com":2002
 Received time from server: midpoint="Oct 26 2018 23:20:44", radius=1000000, verified=No (merkle_index=0)
+Oct 26 2018 23:20:44
+```
+
+### Setting The System Time on Linux
+
+You can use the `date` utility on Linux machines to set the system time to the time determined by the Roughenough client:
+
+```bash
+sudo date --utc --set "$(roughenough-client roughtime.int08h.com 2002)"
 ```
 
 ### Validating Server Responses 
@@ -60,9 +69,10 @@ $ host -t TXT roughtime.int08h.com
 roughtime.int08h.com descriptive text "016e6e0284d24c37c6e4d7d8d5b4e1d3c1949ceaa545bf875616c9dce0c9bec1"
 
 # Validate the server response using its public key
-$ target/release/roughenough-client roughtime.int08h.com 2002 -p 016e6e0284d24c37c6e4d7d8d5b4e1d3c1949ceaa545bf875616c9dce0c9bec1
+$ target/release/roughenough-client -v roughtime.int08h.com 2002 -p 016e6e0284d24c37c6e4d7d8d5b4e1d3c1949ceaa545bf875616c9dce0c9bec1
 Requesting time from: "roughtime.int08h.com":2002
 Received time from server: midpoint="Oct 26 2018 23:22:20", radius=1000000, verified=Yes (merkle_index=0)
+Oct 26 2018 23:22:20
 ```
 
 The **`verified=Yes`** in the output confirms that the server's response had a valid signature.

--- a/src/bin/roughenough-client.rs
+++ b/src/bin/roughenough-client.rs
@@ -222,6 +222,14 @@ fn main() {
       .required(true)
       .help("The Roughtime server port to connect to")
       .takes_value(true))
+    .arg(Arg::with_name("verbose")
+      .short("v")
+      .long("verbose")
+      .help("Print more output"))
+    .arg(Arg::with_name("json")
+      .short("j")
+      .long("json")
+      .help("Print output in JSON"))
     .arg(Arg::with_name("public-key")
       .short("p")
       .long("public-key")
@@ -256,6 +264,8 @@ fn main() {
 
     let host = matches.value_of("host").unwrap();
     let port = value_t_or_exit!(matches.value_of("port"), u16);
+    let verbose = matches.is_present("verbose");
+    let json = matches.is_present("json");
     let num_requests = value_t_or_exit!(matches.value_of("num-requests"), u16) as usize;
     let time_format = matches.value_of("time-format").unwrap();
     let stress = matches.is_present("stress");
@@ -264,7 +274,9 @@ fn main() {
         .map(|pkey| hex::decode(pkey).expect("Error parsing public key!"));
     let out = matches.value_of("output");
 
-    println!("Requesting time from: {:?}:{:?}", host, port);
+    if verbose {
+        println!("Requesting time from: {:?}:{:?}", host, port);
+    }
 
     let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
 
@@ -312,10 +324,21 @@ fn main() {
         let out = spec.format(time_format).to_string();
         let verify_str = if verified { "Yes" } else { "No" };
 
-        println!(
-            "Received time from server: midpoint={:?}, radius={:?}, verified={} (merkle_index={})",
-            out, radius, verify_str, index
-        );
+        if verbose {
+            println!(
+                "Received time from server: midpoint={:?}, radius={:?}, verified={} (merkle_index={})",
+                out, radius, verify_str, index
+            );
+        }
+
+        if json {
+            println!(
+                r#"{{ "midpoint": {:?}, "radius": {:?}, "verified": {}, "merkle_index": {} }}"#,
+                out, radius, verified, index
+            );
+        } else {
+            println!("{}", out);
+        }
     }
 }
 

--- a/src/bin/roughenough-client.rs
+++ b/src/bin/roughenough-client.rs
@@ -275,7 +275,7 @@ fn main() {
     let out = matches.value_of("output");
 
     if verbose {
-        println!("Requesting time from: {:?}:{:?}", host, port);
+        eprintln!("Requesting time from: {:?}:{:?}", host, port);
     }
 
     let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
@@ -325,7 +325,7 @@ fn main() {
         let verify_str = if verified { "Yes" } else { "No" };
 
         if verbose {
-            println!(
+            eprintln!(
                 "Received time from server: midpoint={:?}, radius={:?}, verified={} (merkle_index={})",
                 out, radius, verify_str, index
             );


### PR DESCRIPTION
Fixes #20.

This PR adds some options for the output of the roughenough client. By default, now, the client will output just the time that it loaded from the server. If the `--verbose` flag is supplied, it will additionally print the output that it used to as it makes requests and gets responses. If the `--json` flag is supplied it will output responses in JSON format instead.

Also, all non-response text is output to standard error to allow you to get the verbose notifications in the terminal while the command is running, but to redirect the actual response(s) to a file or pipe like so:

```
$ roughenough-client -v time.server.domain 1234 > time.txt
Requesting time from: "time.server.domain":1234
Received time from server: midpoint="Oct 08 2019 18:40:38", radius=1000000, verified=No (merkle_index=0)
$ cat time.txt
Oct 08 2019 18:40:38
```
I updated the README's instructions to match the new client behaviour and I added instructions for setting the system time on Linux using the Roughenough client. ( which is my particular use-case :slightly_smiling_face: ) 

And the DCO:

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```