### PR TITLE
Refactor signing and verification to use ed25519-dalek

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ yaml-rust = "0.4"
 zeroize = "1.8"
 data-encoding = "2.6"
 enum-iterator = "2.1"
+ed25519-dalek = "2.1"
 
 # Used by 'awskms' and 'gcpkms'
 futures = { version = "^0.3", optional = true }

--- a/src/bin/roughenough-client.rs
+++ b/src/bin/roughenough-client.rs
@@ -33,7 +33,7 @@ use ring::rand;
 use ring::rand::SecureRandom;
 use roughenough::key::LongTermKey;
 use roughenough::merkle::MerkleTree;
-use roughenough::sign::Verifier;
+use roughenough::sign::MsgVerifier;
 use roughenough::version::Version;
 use roughenough::{
     roughenough_version, Error, RtMessage, Tag, CERTIFICATE_CONTEXT, REQUEST_FRAMING_BYTES,
@@ -314,7 +314,7 @@ impl ResponseHandler {
     }
 
     fn validate_sig(&self, public_key: &[u8], sig: &[u8], data: &[u8]) -> bool {
-        let mut verifier = Verifier::new(public_key);
+        let mut verifier = MsgVerifier::new(public_key);
         verifier.update(data);
         verifier.verify(sig)
     }

--- a/src/key/longterm.rs
+++ b/src/key/longterm.rs
@@ -18,7 +18,7 @@
 
 use crate::key::OnlineKey;
 use crate::message::RtMessage;
-use crate::sign::Signer;
+use crate::sign::MsgSigner;
 use crate::tag::Tag;
 use crate::CERTIFICATE_CONTEXT;
 use ring::digest;
@@ -30,7 +30,7 @@ use std::fmt::Formatter;
 /// Represents the server's long-term identity.
 ///
 pub struct LongTermKey {
-    signer: Signer,
+    signer: MsgSigner,
     srv_value: Vec<u8>,
 }
 
@@ -43,8 +43,8 @@ impl LongTermKey {
     }
 
     pub fn new(seed: &[u8]) -> Self {
-        let signer = Signer::from_seed(seed);
-        let srv_value = LongTermKey::calc_srv_value(signer.public_key_bytes());
+        let signer = MsgSigner::from_seed(seed);
+        let srv_value = LongTermKey::calc_srv_value(&signer.public_key_bytes());
 
         LongTermKey {
             signer,
@@ -70,7 +70,7 @@ impl LongTermKey {
     }
 
     /// Return the public key for the provided seed
-    pub fn public_key(&self) -> &[u8] {
+    pub fn public_key(&self) -> Vec<u8> {
         self.signer.public_key_bytes()
     }
 

--- a/src/key/online.rs
+++ b/src/key/online.rs
@@ -19,7 +19,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use byteorder::{LittleEndian, WriteBytesExt};
 
 use crate::message::RtMessage;
-use crate::sign::Signer;
+use crate::sign::MsgSigner;
 use crate::tag::Tag;
 use crate::version::Version;
 use crate::SIGNED_RESPONSE_CONTEXT;
@@ -28,7 +28,7 @@ use crate::SIGNED_RESPONSE_CONTEXT;
 /// Represents the delegated Roughtime ephemeral online key.
 ///
 pub struct OnlineKey {
-    signer: Signer,
+    signer: MsgSigner,
 }
 
 impl Default for OnlineKey {
@@ -40,7 +40,7 @@ impl Default for OnlineKey {
 impl OnlineKey {
     pub fn new() -> Self {
         OnlineKey {
-            signer: Signer::new(),
+            signer: MsgSigner::new(),
         }
     }
 
@@ -51,7 +51,7 @@ impl OnlineKey {
         let pub_key_bytes = self.signer.public_key_bytes();
 
         let mut dele_msg = RtMessage::with_capacity(3);
-        dele_msg.add_field(Tag::PUBK, pub_key_bytes).unwrap();
+        dele_msg.add_field(Tag::PUBK, &pub_key_bytes).unwrap();
         dele_msg.add_field(Tag::MINT, &zeros).unwrap();
         dele_msg.add_field(Tag::MAXT, &max).unwrap();
 

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -25,13 +25,12 @@ use data_encoding::{Encoding, HEXLOWER_PERMISSIVE};
 use mio::net::UdpSocket;
 
 use crate::config::ServerConfig;
-use crate::error::Error::SendingResponseFailed;
 use crate::grease::Grease;
 use crate::key::{LongTermKey, OnlineKey};
 use crate::merkle::MerkleTree;
 use crate::stats::ServerStats;
 use crate::version::Version;
-use crate::{Error, RtMessage, Tag};
+use crate::{RtMessage, Tag};
 
 const HEX: Encoding = HEXLOWER_PERMISSIVE;
 
@@ -50,7 +49,7 @@ impl Responder {
     pub fn new(version: Version, config: &dyn ServerConfig, ltk: &mut LongTermKey) -> Responder {
         let online_key = OnlineKey::new();
         let cert_bytes = ltk.make_cert(&online_key).encode().expect("make_cert");
-        let long_term_public_key = HEX.encode(ltk.public_key());
+        let long_term_public_key = HEX.encode(&ltk.public_key());
         let requests = Vec::with_capacity(config.batch_size() as usize);
         let grease = Grease::new(config.fault_percentage());
         let thread_id = thread::current().name().unwrap().to_string();


### PR DESCRIPTION
`perf` shows the server spends most of its time in signature generation. Benchmarking shows ed25519-dalek is about 40% faster than Ring generating signatures on x86_64.

Replaced Verifier and Signer with ed25519-dalek for signature operations. Updated relevant imports and function calls.