### PR TITLE
Fix interoperability issues with draft-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ by the RFC is used to distinguish classic vs. RFC requests).
 
 The new `-p/--protocol` flag of `roughenough-client` controls the protocol version to
 use in requests. `0` = classic protocol (no `VER` tag), `1` = anticipated RFC protocol 
-(`VER` tag with value `0x00000001`), and `8` is the RFC Draft11 protocol (`VER` tag with
+(`VER` tag with value `0x00000001`), and `11` is the RFC Draft11 protocol (`VER` tag with
 value `0x0b000008`). The default is `0` the "classic" protocol, until the RFC is finalized.
 
 ```
@@ -87,7 +87,7 @@ sudo date -u "$(roughenough-client -z roughtime.int08h.com 2002 -f %Y%m%d%H%M.%S
 
 ### Validating Server Responses 
 
-Use the `-p` flag with the client to validate the server's response with its public key.
+Use the `-k` flag with the client to validate the server's response with its public key.
 
 ```bash
 # The public key of 'roughtime.int08h.com' is stored in a DNS TXT record 

--- a/src/bin/roughenough-client.rs
+++ b/src/bin/roughenough-client.rs
@@ -383,7 +383,7 @@ fn main() {
             .short("p")
             .long("protocol")
             .takes_value(true)
-            .help("Roughtime protocol version to use (0 = classic, 1 = rfc, 8 = draft8)")
+            .help("Roughtime protocol version to use (0 = classic, 1 = rfc, 11 = draft11)")
             .default_value("0")
         )
         .arg(Arg::with_name("timeout")
@@ -428,7 +428,7 @@ fn main() {
         1 => Version::Rfc,
         11 => Version::RfcDraft11,
         _ => panic!(
-            "Invalid protocol '{}'; valid values are 0, 1, or 8",
+            "Invalid protocol '{}'; valid values are 0, 1, or 11",
             protocol
         ),
     };

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -105,7 +105,7 @@ impl Responder {
         for (idx, &(ref nonce, ref src_addr)) in self.requests.iter().enumerate() {
             let paths = self.merkle.get_paths(idx);
             let resp_msg = {
-                let r = self.make_response(&srep, &self.cert_bytes, &paths, idx as u32);
+                let r = self.make_response(&srep, &self.cert_bytes, &paths, idx as u32, nonce);
                 if self.grease.should_add_error() {
                     self.grease.add_errors(&r)
                 } else {
@@ -155,6 +155,7 @@ impl Responder {
         cert_bytes: &[u8],
         path: &[u8],
         idx: u32,
+        nonce: &Vec<u8>,
     ) -> RtMessage {
         let mut index = [0; 4];
         (&mut index as &mut [u8])
@@ -173,6 +174,7 @@ impl Responder {
                 .unwrap();
         }
 
+        response.add_field(Tag::NONC, nonce).unwrap();
         response.add_field(Tag::PATH, path).unwrap();
         response.add_field(Tag::SREP, srep_bytes).unwrap();
         response.add_field(Tag::CERT, cert_bytes).unwrap();

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -27,8 +27,8 @@ pub enum Tag {
     //
     // Tags are written here in ascending order
     SIG,
-    SRV,
     VER,
+    SRV,
     DUT1,
     NONC,
     DELE,


### PR DESCRIPTION
Fix a couple of mentions of draft8 that should be draft11, plus an additional typo in the README. The issues were found during the IETF 121 Hackathon in Dublin.