### PR TITLE
Update protocol for draft13 compliance

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,13 +17,6 @@ jobs:
         feature: ["default", "gcpkms", "awskms"]
         toolchain: ["stable", "beta"]
     steps:
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - uses: actions/checkout@v2
     - name: Install Rust ${{ matrix.toolchain }} 
       uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## Version 1.3.0-draft13
+* **Interop testing still needed**. This implementation has undergone initial testing, but
+  is not yet ready for production use.
+* Roughenough tries to strictly implement the Roughtime protocol as described in 
+  [the draft-13 RFC](https://www.ietf.org/archive/id/draft-ietf-ntp-roughtime-13.html). Unlike prior
+  version of Roughenough, now there are no (intentional) deviations from the RFC. Roughenough strives
+  to be a full compliant implementation. Deviations from that ideal are probally bugs.
+* The Roughenough server operates both the "classic" Google protocol __and__ the RFC 
+  compliant protocol at the same time on the same serving port. The 8-byte magic frame value added
+  by the RFC is used to distinguish classic vs. rfc requests.
+* The version value for IETF RFC draft13 (the VER tag) is `0x0800000c`
+* The new `-p/--protocol` flag of `roughenough-client` controls the protocol version to
+  use in requests (`0` = classic protocol, `13` = RFC draft13 protocol). The default is `0` the
+  "classic" protocol, until the RFC is finalized.
+* Summarized changes over prior RFC drafts: 
+  * Hash over the entire request packet in Merkle tree
+  * Check depth of PATH is <32 
+  * Remove trailing "--" from delegation signature context string
+  * Sorted values in `VER` tag
+  * Version number changed to `0x8000000c`
+  * `VER` tag moved inside `SREP`
+  * Added `VERS` tag
+
 ## Version 1.2.0-draft-5
 * Roughenough (mostly) implements the Roughtime protocol as specified in [the draft-5 RFC](https://www.ietf.org/archive/id/draft-ietf-ntp-roughtime-05.html).
   

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roughenough"
-version = "1.3.0-draft12"
+version = "1.3.0-draft13"
 repository = "https://github.com/int08h/roughenough"
 authors = ["Stuart Stock <stuart@int08h.com>", "Aaron Hill <aa1ronham@gmail.com>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ ctrlc = { version = "3.4", features = ["termination"] }
 data-encoding = "2.6"
 ed25519-dalek = "2.1"
 enum-iterator = "2.1"
-humansize = "2"
 log = "0.4"
 mio = "0.6"
 mio-extras = "2.0"
@@ -40,7 +39,6 @@ ring = "0.17"
 simple_logger = "5"
 serde = { version = "1.0", features = ["derive", "std"] }
 yaml-rust = "0.4"
-zeroize = "1.8"
 zstd = {  version = "0.13", features = ["zstdmt"] }
 
 # Used by 'awskms' and 'gcpkms'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ travis-ci = { repository = "int08h/roughenough", branch = "master" }
 
 [features]
 default = []
+fuzzing = []
 awskms = ["rusoto_core", "rusoto_kms", "bytes", "futures"]
 gcpkms = ["google-cloudkms1", "hyper", "hyper-rustls", "yup-oauth2", "futures", "tokio"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ ctrlc = { version = "3.4", features = ["termination"] }
 data-encoding = "2.6"
 ed25519-dalek = "2.1"
 enum-iterator = "2.1"
+fixedbitset = "0.5"
 humansize = "2"
 log = "0.4"
 mio = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ ctrlc = { version = "3.4", features = ["termination"] }
 data-encoding = "2.6"
 ed25519-dalek = "2.1"
 enum-iterator = "2.1"
-fixedbitset = "0.5"
 humansize = "2"
 log = "0.4"
 mio = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ yaml-rust = "0.4"
 zeroize = "1.8"
 data-encoding = "2.6"
 enum-iterator = "2.1"
+crossbeam-queue = "0.3"
 
 # Used by 'awskms' and 'gcpkms'
 futures = { version = "^0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,13 @@ travis-ci = { repository = "int08h/roughenough", branch = "master" }
 [features]
 default = []
 awskms = ["rusoto_core", "rusoto_kms", "bytes", "futures"]
-gcpkms = ["google-cloudkms1", "hyper", "hyper-rustls", "serde", "serde_json", "yup-oauth2", "futures", "tokio"]
+gcpkms = ["google-cloudkms1", "hyper", "hyper-rustls", "yup-oauth2", "futures", "tokio"]
 
 [dependencies]
 byteorder = "1"
 chrono = "0.4"
 clap = "2"
+csv = "1.3"
 ctrlc = { version = "3.4", features = ["termination"] }
 humansize = "2"
 log = "0.4"
@@ -31,6 +32,8 @@ once_cell = "1.19"
 rand = "0.6"
 ring = "0.17"
 simple_logger = "5"
+serde = { version = "1.0", features = ["derive", "std"] }
+serde_json = { version = "1.0"}
 yaml-rust = "0.4"
 zeroize = "1.8"
 data-encoding = "2.6"
@@ -49,8 +52,6 @@ bytes = { version = "^1.0", optional = true }
 google-cloudkms1 = { version = "2.0.8", optional = true }
 hyper = { version = "^0.14", optional = true }
 hyper-rustls = { version = "^0.22", optional = true }
-serde = { version = "^1.0", optional = true }
-serde_json = { version = "^1.0", optional = true }
 yup-oauth2 = { version = "^5.0", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roughenough"
-version = "1.3.0-draft11"
+version = "1.3.0-draft12"
 repository = "https://github.com/int08h/roughenough"
 authors = ["Stuart Stock <stuart@int08h.com>", "Aaron Hill <aa1ronham@gmail.com>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ gcpkms = ["google-cloudkms1", "hyper", "hyper-rustls", "yup-oauth2", "futures", 
 
 [dependencies]
 byteorder = "1"
+ciborium = "0.2.2"
 chrono = "0.4"
 clap = "2"
-csv = "1.3"
 ctrlc = { version = "3.4", features = ["termination"] }
 humansize = "2"
 log = "0.4"
@@ -33,7 +33,6 @@ rand = "0.6"
 ring = "0.17"
 simple_logger = "5"
 serde = { version = "1.0", features = ["derive", "std"] }
-serde_json = { version = "1.0"}
 yaml-rust = "0.4"
 zeroize = "1.8"
 data-encoding = "2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ awskms = ["rusoto_core", "rusoto_kms", "bytes", "futures"]
 gcpkms = ["google-cloudkms1", "hyper", "hyper-rustls", "yup-oauth2", "futures", "tokio"]
 
 [dependencies]
+ahash = "0.8"
 byteorder = "1"
 chrono = "0.4"
 clap = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ gcpkms = ["google-cloudkms1", "hyper", "hyper-rustls", "yup-oauth2", "futures", 
 
 [dependencies]
 byteorder = "1"
-ciborium = "0.2.2"
 chrono = "0.4"
 clap = "2"
+csv = "1.3"
 ctrlc = { version = "3.4", features = ["termination"] }
 humansize = "2"
 log = "0.4"
@@ -33,6 +33,7 @@ rand = "0.6"
 ring = "0.17"
 simple_logger = "5"
 serde = { version = "1.0", features = ["derive", "std"] }
+serde_json = { version = "1.0"}
 yaml-rust = "0.4"
 zeroize = "1.8"
 data-encoding = "2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,12 @@ gcpkms = ["google-cloudkms1", "hyper", "hyper-rustls", "yup-oauth2", "futures", 
 byteorder = "1"
 chrono = "0.4"
 clap = "2"
+crossbeam-queue = "0.3"
 csv = "1.3"
 ctrlc = { version = "3.4", features = ["termination"] }
+data-encoding = "2.6"
+ed25519-dalek = "2.1"
+enum-iterator = "2.1"
 humansize = "2"
 log = "0.4"
 mio = "0.6"
@@ -33,13 +37,9 @@ rand = "0.6"
 ring = "0.17"
 simple_logger = "5"
 serde = { version = "1.0", features = ["derive", "std"] }
-serde_json = { version = "1.0"}
 yaml-rust = "0.4"
 zeroize = "1.8"
-data-encoding = "2.6"
-enum-iterator = "2.1"
-ed25519-dalek = "2.1"
-crossbeam-queue = "0.3"
+zstd = {  version = "0.13", features = ["zstdmt"] }
 
 # Used by 'awskms' and 'gcpkms'
 futures = { version = "^0.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -15,20 +15,24 @@ Requires latest stable Rust to compile. Contributions welcome, see
 
 ## RFC Work-In-Progress
 
-Roughenough implements the Roughtime protocol as specified in [the draft-12 RFC](https://www.ietf.org/archive/id/draft-ietf-ntp-roughtime-12.html).
+**RFC interop testing still needed. This implementation has undergone testing as part
+of its development, but is not yet ready for production use. More testing between
+Roughtime implementations is required.**
+
+Roughenough implements the Roughtime protocol as specified in [the draft-13 RFC](https://www.ietf.org/archive/id/draft-ietf-ntp-roughtime-13.html).
 
 The Roughenough server operates both the "classic" protocol **and** the RFC compliant 
 protocol at the same time on a single serving port (the 8-byte magic frame value added 
 by the RFC is used to distinguish classic vs. RFC requests).
 
 The new `-p/--protocol` flag of `roughenough-client` controls the protocol version to
-use in requests. `0` = classic protocol (no `VER` tag), `1` = anticipated RFC protocol 
-(`VER` tag with value `0x00000001`), and `8` is the RFC Draft12 protocol (`VER` tag with
-value `0x0b00000c`). The default is `0` the "classic" protocol, until the RFC is finalized.
+use in requests. `0` = "classic" Google protocol (no `VER` tag), and `13` is the RFC 
+Draft13 protocol (`VER` tag with value `0x0b00000c`). The default is `0` the "classic" 
+protocol, until the RFC is finalized.
 
 ```
 # send RFC protocol Roughtime requests
-$ roughenough-client -p 1 roughtime.int08h.com 2002
+$ roughenough-client -p 13 roughtime.int08h.com 2002
 ```
 
 ## Links
@@ -228,7 +232,7 @@ created by Adam Langley and Robert Obryk.
 * Eric Swanson (github.com/lachesis)
 
 ## Copyright and License
-Roughenough is copyright (c) 2017-2024 int08h LLC. All rights reserved. 
+Roughenough is copyright (c) 2017-2025 int08h LLC. All rights reserved. 
 
 int08h LLC licenses Roughenough (the "Software") to you under the Apache License, version 2.0 
 (the "License"); you may not use this Software except in compliance with the License. You may obtain 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requires latest stable Rust to compile. Contributions welcome, see
 
 ## RFC Work-In-Progress
 
-Roughenough implements the Roughtime protocol as specified in [the draft-11 RFC](https://www.ietf.org/archive/id/draft-ietf-ntp-roughtime-11.html).
+Roughenough implements the Roughtime protocol as specified in [the draft-12 RFC](https://www.ietf.org/archive/id/draft-ietf-ntp-roughtime-12.html).
 
 The Roughenough server operates both the "classic" protocol **and** the RFC compliant 
 protocol at the same time on a single serving port (the 8-byte magic frame value added 
@@ -23,8 +23,8 @@ by the RFC is used to distinguish classic vs. RFC requests).
 
 The new `-p/--protocol` flag of `roughenough-client` controls the protocol version to
 use in requests. `0` = classic protocol (no `VER` tag), `1` = anticipated RFC protocol 
-(`VER` tag with value `0x00000001`), and `8` is the RFC Draft11 protocol (`VER` tag with
-value `0x0b000008`). The default is `0` the "classic" protocol, until the RFC is finalized.
+(`VER` tag with value `0x00000001`), and `8` is the RFC Draft12 protocol (`VER` tag with
+value `0x0b00000c`). The default is `0` the "classic" protocol, until the RFC is finalized.
 
 ```
 # send RFC protocol Roughtime requests
@@ -112,16 +112,16 @@ There are two (mutually exclusive) ways to configure the Roughenough server:
 
 The server accepts the following configuration parameters:
 
-YAML Key | Environment Variable | Necessity | Description
---- | --- | --- | ---
-`interface` | `ROUGHENOUGH_INTERFACE` | Required | IP address or interface name for listening to client requests
-`port` | `ROUGHENOUGH_PORT` | Required | UDP port to listen for requests
-`seed` | `ROUGHENOUGH_SEED` | Required | A 32-byte hexadecimal value used to generate the server's long-term key pair. **This is a secret value and must be un-guessable**, treat it with care. (If compiled with KMS support, length will vary; see [Optional Features](#optional-features))
-`batch_size` | `ROUGHENOUGH_BATCH_SIZE` | Optional | The maximum number of requests to process in one batch. All nonces in a batch are used to build a Merkle tree, the root of which is signed. Default is `64` requests per batch.
-`status_interval` | `ROUGHENOUGH_STATUS_INTERVAL` | Optional | Number of _seconds_ between each logged status update. Default is `600` seconds (10 minutes).
-`health_check_port` | `ROUGHENOUGH_HEALTH_CHECK_PORT` | Optional | If present, enable an HTTP health check responder on the provided port. **Use with caution**, see [Optional Features](#optional-features).
-`kms_protection` | `ROUGHENOUGH_KMS_PROTECTION` | Optional | If compiled with KMS support, the ID of the KMS key used to protect the long-term identity. See [Optional Features](#optional-features).
-`fault_percentage` | `ROUGHENOUGH_FAULT_PERCENTAGE` | Optional | Likelihood (as a percentage) that the server will intentionally return an invalid client response. An integer range from `0` (disabled, all responses valid) to `50` (50% of responses will be invalid). Default is `0` (disabled).
+| YAML Key            | Environment Variable            | Necessity | Description                                                                                                                                                                                                                                          |
+|---------------------|---------------------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `interface`         | `ROUGHENOUGH_INTERFACE`         | Required  | IP address or interface name for listening to client requests                                                                                                                                                                                        |
+| `port`              | `ROUGHENOUGH_PORT`              | Required  | UDP port to listen for requests                                                                                                                                                                                                                      |
+| `seed`              | `ROUGHENOUGH_SEED`              | Required  | A 32-byte hexadecimal value used to generate the server's long-term key pair. **This is a secret value and must be un-guessable**, treat it with care. (If compiled with KMS support, length will vary; see [Optional Features](#optional-features)) |
+| `batch_size`        | `ROUGHENOUGH_BATCH_SIZE`        | Optional  | The maximum number of requests to process in one batch. All nonces in a batch are used to build a Merkle tree, the root of which is signed. Default is `64` requests per batch.                                                                      |
+| `status_interval`   | `ROUGHENOUGH_STATUS_INTERVAL`   | Optional  | Number of _seconds_ between each logged status update. Default is `600` seconds (10 minutes).                                                                                                                                                        |
+| `health_check_port` | `ROUGHENOUGH_HEALTH_CHECK_PORT` | Optional  | If present, enable an HTTP health check responder on the provided port. **Use with caution**, see [Optional Features](#optional-features).                                                                                                           |
+| `kms_protection`    | `ROUGHENOUGH_KMS_PROTECTION`    | Optional  | If compiled with KMS support, the ID of the KMS key used to protect the long-term identity. See [Optional Features](#optional-features).                                                                                                             |
+| `fault_percentage`  | `ROUGHENOUGH_FAULT_PERCENTAGE`  | Optional  | Likelihood (as a percentage) that the server will intentionally return an invalid client response. An integer range from `0` (disabled, all responses valid) to `50` (50% of responses will be invalid). Default is `0` (disabled).                  |
 
 #### YAML Configuration 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requires latest stable Rust to compile. Contributions welcome, see
 
 ## RFC Work-In-Progress
 
-Roughenough implements the Roughtime protocol as specified in [the draft-8 RFC](https://www.ietf.org/archive/id/draft-ietf-ntp-roughtime-08.html).
+Roughenough implements the Roughtime protocol as specified in [the draft-11 RFC](https://www.ietf.org/archive/id/draft-ietf-ntp-roughtime-11.html).
 
 The Roughenough server operates both the "classic" protocol **and** the RFC compliant 
 protocol at the same time on a single serving port (the 8-byte magic frame value added 
@@ -23,8 +23,8 @@ by the RFC is used to distinguish classic vs. RFC requests).
 
 The new `-p/--protocol` flag of `roughenough-client` controls the protocol version to
 use in requests. `0` = classic protocol (no `VER` tag), `1` = anticipated RFC protocol 
-(`VER` tag with value `0x00000001`), and `8` is the RFC Draft8 protocol (`VER` tag with
-value `0x80000008`). The default is `0` the "classic" protocol, until the RFC is finalized.
+(`VER` tag with value `0x00000001`), and `8` is the RFC Draft11 protocol (`VER` tag with
+value `0x0b000008`). The default is `0` the "classic" protocol, until the RFC is finalized.
 
 ```
 # send RFC protocol Roughtime requests

--- a/benches/roughenough-bench.rs
+++ b/benches/roughenough-bench.rs
@@ -19,7 +19,7 @@ fn create_signed_srep_tags(c: &mut Criterion) {
 
     group.throughput(Elements(1));
     group.bench_function("create signed SREP tag", |b| {
-        b.iter(|| black_box(key.make_srep(Version::Rfc, now, &data)))
+        b.iter(|| black_box(key.make_srep(Version::RfcDraft13, now, &data)))
     });
     group.finish();
 }
@@ -62,7 +62,7 @@ fn create_new_merkle_tree(c: &mut Criterion) {
         group.throughput(Elements(*size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
             b.iter(|| {
-                let mut tree = MerkleTree::new_sha512_classic();
+                let mut tree = MerkleTree::new_sha512_google();
                 for _ in 0..size {
                     tree.push_leaf(DATA);
                 }
@@ -77,7 +77,7 @@ fn reuse_merkle_tree(c: &mut Criterion) {
     let mut group = c.benchmark_group("reuse Merkle tree");
     group.sampling_mode(SamplingMode::Flat);
 
-    let mut tree = MerkleTree::new_sha512_classic();
+    let mut tree = MerkleTree::new_sha512_google();
 
     for size in SIZES.iter() {
         group.throughput(Elements(*size as u64));

--- a/doc/draft13-todo.txt
+++ b/doc/draft13-todo.txt
@@ -1,15 +1,19 @@
 Review draft 13 vs draft 12
 
-Sorted values in VER tag
-In requests, the version numbers in the VER tag now have to be sorted in
-ascending numerical order.
+--- DONE ---
+DONE, NEEDS TESTING Hash over the entire request packet used in Merkle tree
+As another mitigation against version downgrade attacks, the hash value
+of the entire request packet, including the ROUGHTIM header, is used for
+building the Merkle tree (instead of the NONC value). This means that
+any changes to the request packet will cause the client's verification
+of the response to fail.
 
-Maximum PATH length introduced
+DONE Maximum PATH length introduced
 The length of PATH is not limited to 32. This has no effect in practice
 (unless someone is signing 2^32 responses at once) and serves to
 simplify implementations.
 
-Changed delegation signature context string
+DONE Changed delegation signature context string
 During the Hackathon, we discovered that the two dashes at the end of
 the delegation signature context string had been removed and then added
 again by mistake in a subsequent draft. Since we are already making
@@ -17,15 +21,10 @@ breaking changes in this update, we decided to fix this at the same
 time. The dashes have once again been removed from the delegation
 signature context string.
 
-Hash over the entire request packet used in Merkle tree
-As another mitigation against version downgrade attacks, the hash value
-of the entire request packet, including the ROUGHTIM header, is used for
-building the Merkle tree (instead of the NONC value). This means that
-any changes to the request packet will cause the client's verification
-of the response to fail.
+DONE Sorted values in VER tag
+In requests, the version numbers in the VER tag now have to be sorted in
+ascending numerical order.
 
-
---- DONE ---
 DONE Draft version number changed to 0x8000000c
 We have received requests not to change the draft version numbers unless
 we make changes to the line protocol. However, since we made breaking

--- a/doc/draft13-todo.txt
+++ b/doc/draft13-todo.txt
@@ -1,0 +1,43 @@
+Review draft 13 vs draft 12
+
+Sorted values in VER tag
+In requests, the version numbers in the VER tag now have to be sorted in
+ascending numerical order.
+
+Maximum PATH length introduced
+The length of PATH is not limited to 32. This has no effect in practice
+(unless someone is signing 2^32 responses at once) and serves to
+simplify implementations.
+
+Changed delegation signature context string
+During the Hackathon, we discovered that the two dashes at the end of
+the delegation signature context string had been removed and then added
+again by mistake in a subsequent draft. Since we are already making
+breaking changes in this update, we decided to fix this at the same
+time. The dashes have once again been removed from the delegation
+signature context string.
+
+Hash over the entire request packet used in Merkle tree
+As another mitigation against version downgrade attacks, the hash value
+of the entire request packet, including the ROUGHTIM header, is used for
+building the Merkle tree (instead of the NONC value). This means that
+any changes to the request packet will cause the client's verification
+of the response to fail.
+
+
+--- DONE ---
+DONE Draft version number changed to 0x8000000c
+We have received requests not to change the draft version numbers unless
+we make changes to the line protocol. However, since we made breaking
+changes in this update, we had to bump the version number.
+
+DONE VER tag moved inside SREP
+During the hackathon, we realized that the protocol is vulnerable to
+version downgrade attacks. Moving the VER tag inside SREP ensures that
+it is authenticated.
+
+DONE VERS tag introduced
+The VERS tag has been added to SREP. It provides clients with an
+authenticated list of versions supported by the server, making version
+downgrade attacks where the attacker selectively drops packets with
+certain versions detectable by the client.

--- a/src/bin/roughenough-client.rs
+++ b/src/bin/roughenough-client.rs
@@ -63,10 +63,7 @@ fn create_nonce(ver: Version) -> Nonce {
 fn make_request(ver: Version, nonce: &Nonce, text_dump: bool, pub_key: &Option<Vec<u8>>) -> Vec<u8> {
     let mut msg = RtMessage::with_capacity(3);
 
-    let srv_value = match pub_key {
-        None => None,
-        Some(ref pk) => Some(LongTermKey::calc_srv_value(&pk)),
-    };
+    let srv_value = pub_key.as_ref().map(|pk| LongTermKey::calc_srv_value(pk));
 
     match ver {
         Version::Classic => {
@@ -121,7 +118,7 @@ fn receive_response(ver: Version, buf: &[u8], buf_len: usize) -> RtMessage {
     match ver {
         Version::Classic => RtMessage::from_bytes(&buf[0..buf_len]).unwrap(),
         Version::Rfc | Version::RfcDraft11 => {
-            verify_framing(&buf).unwrap();
+            verify_framing(buf).unwrap();
             RtMessage::from_bytes(&buf[12..buf_len]).unwrap()
         }
     }

--- a/src/bin/roughenough-client.rs
+++ b/src/bin/roughenough-client.rs
@@ -52,7 +52,7 @@ fn create_nonce(ver: Version) -> Nonce {
             rng.fill(&mut nonce).unwrap();
             nonce.to_vec()
         }
-        Version::Rfc | Version::RfcDraft11 => {
+        Version::Rfc | Version::RfcDraft12 => {
             let mut nonce = [0u8; 32];
             rng.fill(&mut nonce).unwrap();
             nonce.to_vec()
@@ -88,7 +88,7 @@ fn make_request(
 
             msg.encode().unwrap()
         }
-        Version::Rfc | Version::RfcDraft11 => {
+        Version::Rfc | Version::RfcDraft12 => {
             if srv_value.is_some() {
                 let val = srv_value.as_ref().unwrap();
                 msg.add_field(Tag::SRV, val).unwrap();
@@ -122,7 +122,7 @@ fn make_request(
 fn receive_response(ver: Version, buf: &[u8], buf_len: usize) -> RtMessage {
     match ver {
         Version::Classic => RtMessage::from_bytes(&buf[0..buf_len]).unwrap(),
-        Version::Rfc | Version::RfcDraft11 => {
+        Version::Rfc | Version::RfcDraft12 => {
             verify_framing(buf).unwrap();
             RtMessage::from_bytes(&buf[12..buf_len]).unwrap()
         }
@@ -278,7 +278,7 @@ impl ResponseHandler {
 
         let hash = match self.version {
             Version::Classic => MerkleTree::new_sha512_classic(),
-            Version::Rfc | Version::RfcDraft11 => MerkleTree::new_sha512_ietf(),
+            Version::Rfc | Version::RfcDraft12 => MerkleTree::new_sha512_ietf(),
         }
         .root_from_paths(index as usize, &self.nonce, paths);
 
@@ -428,7 +428,7 @@ fn main() {
     let version = match protocol {
         0 => Version::Classic,
         1 => Version::Rfc,
-        11 => Version::RfcDraft11,
+        11 => Version::RfcDraft12,
         _ => panic!(
             "Invalid protocol '{}'; valid values are 0, 1, or 8",
             protocol
@@ -515,7 +515,7 @@ fn main() {
                 let nsecs = (midpoint - (seconds * 10_u64.pow(6))) * 10_u64.pow(3);
                 (seconds, nsecs as u32)
             }
-            Version::Rfc | Version::RfcDraft11 => (midpoint, 0),
+            Version::Rfc | Version::RfcDraft12 => (midpoint, 0),
         };
 
         let verify_str = if verified { "Yes" } else { "No" };

--- a/src/bin/roughenough-client.rs
+++ b/src/bin/roughenough-client.rs
@@ -60,7 +60,12 @@ fn create_nonce(ver: Version) -> Nonce {
     }
 }
 
-fn make_request(ver: Version, nonce: &Nonce, text_dump: bool, pub_key: &Option<Vec<u8>>) -> Vec<u8> {
+fn make_request(
+    ver: Version,
+    nonce: &Nonce,
+    text_dump: bool,
+    pub_key: &Option<Vec<u8>>,
+) -> Vec<u8> {
     let mut msg = RtMessage::with_capacity(3);
 
     let srv_value = pub_key.as_ref().map(|pk| LongTermKey::calc_srv_value(pk));
@@ -157,7 +162,7 @@ fn stress_test_forever(ver: Version, addr: &SocketAddr) -> ! {
     } else {
         "0.0.0.0:0"
     })
-        .expect("Couldn't open UDP socket");
+    .expect("Couldn't open UDP socket");
     let request = make_request(ver, &nonce, false, &None);
     loop {
         socket.send_to(&request, addr).unwrap();
@@ -449,7 +454,7 @@ fn main() {
         } else {
             "0.0.0.0:0"
         })
-            .expect("Couldn't open UDP socket");
+        .expect("Couldn't open UDP socket");
         let request = make_request(version, &nonce, text_dump, &pub_key);
 
         if let Some(f) = file_for_requests.as_mut() {

--- a/src/bin/roughenough-server.rs
+++ b/src/bin/roughenough-server.rs
@@ -180,11 +180,11 @@ pub fn main() {
     let client_stats_enabled = config.lock().unwrap().client_stats_enabled();
     let persistence_directory = config.lock().unwrap().persistence_directory();
 
-    if client_stats_enabled && persistence_directory.is_some() {
+    if client_stats_enabled {
         let mut reporter = Reporter::new(
             stats_queue.clone(),
             &config.lock().unwrap().status_interval(),
-            persistence_directory.unwrap().as_path(),
+            persistence_directory,
         );
 
         let report_thread = thread::Builder::new()

--- a/src/bin/roughenough-server.rs
+++ b/src/bin/roughenough-server.rs
@@ -23,13 +23,6 @@
 #[macro_use]
 extern crate log;
 
-use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::{env, io, thread};
-use std::ops::Deref;
-use std::path::Path;
-use std::time::Duration;
 use log::LevelFilter;
 use mio::net::UdpSocket;
 use mio::Events;
@@ -37,6 +30,11 @@ use net2::unix::UnixUdpBuilderExt;
 use net2::UdpBuilder;
 use once_cell::sync::Lazy;
 use simple_logger::SimpleLogger;
+use std::ops::Deref;
+use std::process;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::{env, io, thread};
 
 use roughenough::config;
 use roughenough::config::ServerConfig;
@@ -44,7 +42,7 @@ use roughenough::roughenough_version;
 use roughenough::server::Server;
 use roughenough::stats::{Reporter, StatsQueue};
 
-// All processing threads poll this. Starts TRUE and will be set to FASLE by
+// All processing threads poll this. Starts TRUE and will be set to FALSE by
 // the Ctrl-C (SIGINT) handler created in `set_ctrlc_handler()`
 static KEEP_RUNNING: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(true));
 

--- a/src/bin/roughenough-server.rs
+++ b/src/bin/roughenough-server.rs
@@ -123,7 +123,10 @@ fn display_config(server: &Server, cfg: &dyn ServerConfig) {
         }
     );
     if cfg.client_stats_enabled() && cfg.persistence_directory().is_some() {
-        info!("Persistence directory      : {}", cfg.persistence_directory().unwrap().display());
+        info!(
+            "Persistence directory      : {}",
+            cfg.persistence_directory().unwrap().display()
+        );
     }
     if cfg.fault_percentage() > 0 {
         info!("Deliberate response errors : ~{}%", cfg.fault_percentage());
@@ -189,7 +192,7 @@ pub fn main() {
 
         let report_thread = thread::Builder::new()
             .name("stats-reporting".to_string())
-            .spawn(move || { reporter.processing_loop(KEEP_RUNNING.deref()) })
+            .spawn(move || reporter.processing_loop(KEEP_RUNNING.deref()))
             .expect("failure spawning thread");
 
         threads.push(report_thread);

--- a/src/config/environment.rs
+++ b/src/config/environment.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use data_encoding::{Encoding, HEXLOWER_PERMISSIVE};
+use std::path::PathBuf;
 use std::time::Duration;
 use std::{env, thread};
-use std::path::{PathBuf};
-use data_encoding::{Encoding, HEXLOWER_PERMISSIVE};
 
 use crate::config::ServerConfig;
 use crate::config::{DEFAULT_BATCH_SIZE, DEFAULT_STATUS_INTERVAL};

--- a/src/config/environment.rs
+++ b/src/config/environment.rs
@@ -28,19 +28,19 @@ const HEX: Encoding = HEXLOWER_PERMISSIVE;
 /// Obtain a Roughenough server configuration ([ServerConfig](trait.ServerConfig.html))
 /// from environment variables.
 ///
-///   Config parameter  | Environment Variable
-///   ----------------  | --------------------
-///   port              | `ROUGHENOUGH_PORT`
-///   interface         | `ROUGHENOUGH_INTERFACE`
-///   seed              | `ROUGHENOUGH_SEED`
-///   batch_size        | `ROUGHENOUGH_BATCH_SIZE`
-///   status_interval   | `ROUGHENOUGH_STATUS_INTERVAL`
-///   kms_protection    | `ROUGHENOUGH_KMS_PROTECTION`
-///   health_check_port | `ROUGHENOUGH_HEALTH_CHECK_PORT`
-///   client_stats      | `ROUGHENOUGH_CLIENT_STATS`
-///   fault_percentage  | `ROUGHENOUGH_FAULT_PERCENTAGE`
-///   num_workers       | `ROUGHENOUGH_NUM_WORKERS`
-///   stats_dir         | `ROUGHENOUGH_STATS_DIR`
+///   Config parameter      | Environment Variable
+///   ----------------      | --------------------
+///   port                  | `ROUGHENOUGH_PORT`
+///   interface             | `ROUGHENOUGH_INTERFACE`
+///   seed                  | `ROUGHENOUGH_SEED`
+///   batch_size            | `ROUGHENOUGH_BATCH_SIZE`
+///   status_interval       | `ROUGHENOUGH_STATUS_INTERVAL`
+///   kms_protection        | `ROUGHENOUGH_KMS_PROTECTION`
+///   health_check_port     | `ROUGHENOUGH_HEALTH_CHECK_PORT`
+///   client_stats          | `ROUGHENOUGH_CLIENT_STATS`
+///   fault_percentage      | `ROUGHENOUGH_FAULT_PERCENTAGE`
+///   num_workers           | `ROUGHENOUGH_NUM_WORKERS`
+///   persistence_directory | `ROUGHENOUGH_PERSISTENCE_DIRECTORY`
 ///
 ///
 pub struct EnvironmentConfig {

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -14,6 +14,7 @@
 
 use std::fs::File;
 use std::io::Read;
+use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
@@ -50,6 +51,7 @@ pub struct FileConfig {
     client_stats: bool,
     fault_percentage: u8,
     num_workers: usize,
+    persist_dir: Option<PathBuf>,
 }
 
 impl FileConfig {
@@ -83,6 +85,7 @@ impl FileConfig {
             client_stats: false,
             fault_percentage: 0,
             num_workers: thread::available_parallelism().unwrap().get(),
+            persist_dir: None,
         };
 
         for (key, value) in cfg[0].as_hash().unwrap() {
@@ -114,6 +117,13 @@ impl FileConfig {
                 "client_stats" => {
                     let val = value.as_str().unwrap().to_ascii_lowercase();
                     config.client_stats = val == "yes" || val == "on";
+                }
+                "persistence_directory" => {
+                    let val = match value.as_str() {
+                        Some(path) => Some(PathBuf::from(path)),
+                        None => None
+                    };
+                    config.persist_dir = val;
                 }
                 "fault_percentage" => {
                     let val = value.as_i64().unwrap() as u8;
@@ -167,6 +177,10 @@ impl ServerConfig for FileConfig {
 
     fn client_stats_enabled(&self) -> bool {
         self.client_stats
+    }
+
+    fn persistence_directory(&self) -> Option<PathBuf> {
+        self.persist_dir.clone()
     }
 
     fn fault_percentage(&self) -> u8 {

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -119,10 +119,7 @@ impl FileConfig {
                     config.client_stats = val == "yes" || val == "on";
                 }
                 "persistence_directory" => {
-                    let val = match value.as_str() {
-                        Some(path) => Some(PathBuf::from(path)),
-                        None => None
-                    };
+                    let val = value.as_str().map(PathBuf::from);
                     config.persist_dir = val;
                 }
                 "fault_percentage" => {

--- a/src/config/memory.rs
+++ b/src/config/memory.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
@@ -88,6 +89,10 @@ impl ServerConfig for MemoryConfig {
 
     fn client_stats_enabled(&self) -> bool {
         self.client_stats
+    }
+
+    fn persistence_directory(&self) -> Option<PathBuf> {
+        None
     }
 
     fn fault_percentage(&self) -> u8 {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -205,28 +205,30 @@ pub fn is_valid_config(cfg: &dyn ServerConfig) -> bool {
         is_valid = false;
     }
 
-    if cfg.client_stats_enabled() && cfg.persistence_directory().is_some() {
-        let dir = cfg.persistence_directory().unwrap();
+    if cfg.client_stats_enabled() {
+        if cfg.persistence_directory().is_some() {
+            let dir = cfg.persistence_directory().unwrap();
 
-        if !dir.is_dir() {
-            error!("stats_persistence_directory {} is not a directory", dir.display());
-            is_valid = false;
-        }
+            if !dir.is_dir() {
+                error!("persistence_directory {} is not a directory", dir.display());
+                is_valid = false;
+            }
 
-        if dir.metadata().unwrap().permissions().readonly() {
-            error!("stats_persistence_directory {} is not writable", dir.display());
+            if dir.metadata().unwrap().permissions().readonly() {
+                error!("persistence_directory {} is not writable", dir.display());
+                is_valid = false;
+            }
+
+        } else {
+            error!("Per-client tracking is enabled (client_stats=true), but no persistence_directory was set");
+            error!("This will result in high memory usage and is likely a misconfiguration");
             is_valid = false;
         }
     }
 
     if is_valid {
         if let Err(e) = cfg.udp_socket_addr() {
-            error!(
-                "failed to create UDP socket {}:{} {:?}",
-                cfg.interface(),
-                cfg.port(),
-                e
-            );
+            error!("failed to create UDP socket {}:{} {:?}", cfg.interface(), cfg.port(), e);
             is_valid = false;
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,12 +22,12 @@
 //! such as files or environment variables.
 //!
 
-use std::net::SocketAddr;
-use std::path::PathBuf;
-use std::time::Duration;
 use crate::key::KmsProtection;
 use crate::Error;
 use crate::SEED_LENGTH;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
 
 pub use self::environment::EnvironmentConfig;
 pub use self::file::FileConfig;
@@ -218,7 +218,6 @@ pub fn is_valid_config(cfg: &dyn ServerConfig) -> bool {
                 error!("persistence_directory {} is not writable", dir.display());
                 is_valid = false;
             }
-
         } else {
             error!("Per-client tracking is enabled (client_stats=true), but no persistence_directory was set");
             error!("This will result in high memory usage and is likely a misconfiguration");
@@ -228,7 +227,12 @@ pub fn is_valid_config(cfg: &dyn ServerConfig) -> bool {
 
     if is_valid {
         if let Err(e) = cfg.udp_socket_addr() {
-            error!("failed to create UDP socket {}:{} {:?}", cfg.interface(), cfg.port(), e);
+            error!(
+                "failed to create UDP socket {}:{} {:?}",
+                cfg.interface(),
+                cfg.port(),
+                e
+            );
             is_valid = false;
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -37,7 +37,7 @@ mod environment;
 mod file;
 mod memory;
 
-/// Maximum number of requests to process in one batch and include the the Merkle tree.
+/// Maximum number of requests to process in one batch and include in the Merkle tree.
 pub const DEFAULT_BATCH_SIZE: u8 = 64;
 
 /// Amount of time between each logged status update.

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
     TagNotStrictlyIncreasing(Tag),
 
     /// The associated byte sequence does not correspond to a valid Roughtime tag.
-    InvalidTag(Box<[u8]>),
+    InvalidTag,
 
     /// Invalid number of tags specified
     InvalidNumTags(u32),

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std;
-
 use crate::kms::KmsError;
 use crate::tag::Tag;
 

--- a/src/grease.rs
+++ b/src/grease.rs
@@ -127,10 +127,18 @@ impl Grease {
 
         let mut new_msg = RtMessage::with_capacity(src_msg.num_fields());
         new_msg.add_field(Tag::SIG, &random_sig).unwrap();
-        new_msg.add_field(Tag::PATH, src_msg.get_field(Tag::PATH).unwrap()).unwrap();
-        new_msg.add_field(Tag::SREP, src_msg.get_field(Tag::SREP).unwrap()).unwrap();
-        new_msg.add_field(Tag::CERT, src_msg.get_field(Tag::CERT).unwrap()).unwrap();
-        new_msg.add_field(Tag::INDX, src_msg.get_field(Tag::INDX).unwrap()).unwrap();
+        new_msg
+            .add_field(Tag::PATH, src_msg.get_field(Tag::PATH).unwrap())
+            .unwrap();
+        new_msg
+            .add_field(Tag::SREP, src_msg.get_field(Tag::SREP).unwrap())
+            .unwrap();
+        new_msg
+            .add_field(Tag::CERT, src_msg.get_field(Tag::CERT).unwrap())
+            .unwrap();
+        new_msg
+            .add_field(Tag::INDX, src_msg.get_field(Tag::INDX).unwrap())
+            .unwrap();
 
         new_msg
     }

--- a/src/grease.rs
+++ b/src/grease.rs
@@ -24,7 +24,7 @@ use rand::distributions::Bernoulli;
 use rand::rngs::SmallRng;
 use rand::seq::index::sample as index_sample;
 use rand::seq::SliceRandom;
-use rand::{FromEntropy, Rng};
+use rand::{FromEntropy, Rng, RngCore};
 
 use crate::grease::Pathologies::*;
 use crate::tag::Tag;
@@ -117,30 +117,20 @@ impl Grease {
     ///
     /// Replace valid SIG signature with random garbage
     ///
-    fn corrupt_response_signature(&self, src_msg: &RtMessage) -> RtMessage {
+    fn corrupt_response_signature(&mut self, src_msg: &RtMessage) -> RtMessage {
         if src_msg.get_field(Tag::SIG).is_none() {
             return src_msg.to_owned();
         }
 
-        let mut prng = SmallRng::from_entropy();
         let mut random_sig: [u8; SIGNATURE_LENGTH as usize] = [0u8; SIGNATURE_LENGTH as usize];
-
-        prng.fill(&mut random_sig);
+        self.prng.fill_bytes(&mut random_sig);
 
         let mut new_msg = RtMessage::with_capacity(src_msg.num_fields());
         new_msg.add_field(Tag::SIG, &random_sig).unwrap();
-        new_msg
-            .add_field(Tag::PATH, src_msg.get_field(Tag::PATH).unwrap())
-            .unwrap();
-        new_msg
-            .add_field(Tag::SREP, src_msg.get_field(Tag::SREP).unwrap())
-            .unwrap();
-        new_msg
-            .add_field(Tag::CERT, src_msg.get_field(Tag::CERT).unwrap())
-            .unwrap();
-        new_msg
-            .add_field(Tag::INDX, src_msg.get_field(Tag::INDX).unwrap())
-            .unwrap();
+        new_msg.add_field(Tag::PATH, src_msg.get_field(Tag::PATH).unwrap()).unwrap();
+        new_msg.add_field(Tag::SREP, src_msg.get_field(Tag::SREP).unwrap()).unwrap();
+        new_msg.add_field(Tag::CERT, src_msg.get_field(Tag::CERT).unwrap()).unwrap();
+        new_msg.add_field(Tag::INDX, src_msg.get_field(Tag::INDX).unwrap()).unwrap();
 
         new_msg
     }
@@ -232,7 +222,7 @@ mod test {
         msg.add_field(Tag::CERT, &[b'2']).unwrap();
         msg.add_field(Tag::INDX, &[b'3']).unwrap();
 
-        let grease = Grease::new(1);
+        let mut grease = Grease::new(1);
         let changed = grease.corrupt_response_signature(&msg);
 
         println!(

--- a/src/key/longterm.rs
+++ b/src/key/longterm.rs
@@ -20,7 +20,7 @@ use crate::key::OnlineKey;
 use crate::message::RtMessage;
 use crate::sign::MsgSigner;
 use crate::tag::Tag;
-use crate::CERTIFICATE_CONTEXT;
+use crate::version::Version;
 use ring::digest;
 use ring::digest::SHA512;
 use std::fmt;
@@ -51,10 +51,10 @@ impl LongTermKey {
 
     /// Create a CERT message with a DELE containing the provided online key
     /// and a SIG of the DELE value signed by the long-term key
-    pub fn make_cert(&mut self, online_key: &OnlineKey) -> RtMessage {
+    pub fn make_cert(&mut self, version: &Version, online_key: &OnlineKey) -> RtMessage {
         let dele_bytes = online_key.make_dele().encode().unwrap();
 
-        self.signer.update(CERTIFICATE_CONTEXT.as_bytes());
+        self.signer.update(version.dele_prefix());
         self.signer.update(&dele_bytes);
 
         let dele_signature = self.signer.sign();

--- a/src/key/longterm.rs
+++ b/src/key/longterm.rs
@@ -46,10 +46,7 @@ impl LongTermKey {
         let signer = MsgSigner::from_seed(seed);
         let srv_value = LongTermKey::calc_srv_value(&signer.public_key_bytes());
 
-        LongTermKey {
-            signer,
-            srv_value,
-        }
+        LongTermKey { signer, srv_value }
     }
 
     /// Create a CERT message with a DELE containing the provided online key

--- a/src/key/online.rs
+++ b/src/key/online.rs
@@ -28,7 +28,7 @@ use crate::version::Version;
 ///
 pub struct OnlineKey {
     signer: MsgSigner,
-    supported_versions: Vec<u8>,
+    vers_wire_bytes: Vec<u8>,
 }
 
 impl Default for OnlineKey {
@@ -41,7 +41,7 @@ impl OnlineKey {
     pub fn new() -> Self {
         OnlineKey {
             signer: MsgSigner::new(),
-            supported_versions: Version::supported_versions_wire(),
+            vers_wire_bytes: Version::supported_versions_wire(),
         }
     }
 
@@ -88,8 +88,8 @@ impl OnlineKey {
 
         // RADI is hard coded at 5 seconds (providing a 10-second measurement window overall)
         let radi_time = match version {
-            Version::Classic => 5_000_000, // five seconds in microseconds
-            Version::RfcDraft12 => 5,      // five seconds
+            Version::Google => 5_000_000, // five seconds in microseconds
+            Version::RfcDraft13 => 5,      // five seconds
         };
 
         (&mut radi as &mut [u8])
@@ -97,8 +97,8 @@ impl OnlineKey {
             .unwrap();
 
         let midp_time = match version {
-            Version::Classic => self.classic_midp(now),
-            Version::RfcDraft12 => self.rfc_midp(now),
+            Version::Google => self.classic_midp(now),
+            Version::RfcDraft13 => self.rfc_midp(now),
         };
 
         (&mut midp as &mut [u8])
@@ -106,7 +106,7 @@ impl OnlineKey {
             .unwrap();
 
         // Signed response SREP
-        let srep_bytes = if version == Version::Classic {
+        let srep_bytes = if version == Version::Google {
             let mut srep_msg = RtMessage::with_capacity(3);
             srep_msg.add_field(Tag::RADI, &radi).unwrap();
             srep_msg.add_field(Tag::MIDP, &midp).unwrap();
@@ -118,7 +118,7 @@ impl OnlineKey {
             srep_msg.add_field(Tag::RADI, &radi).unwrap();
             srep_msg.add_field(Tag::MIDP, &midp).unwrap();
             srep_msg
-                .add_field(Tag::VERS, &self.supported_versions)
+                .add_field(Tag::VERS, &self.vers_wire_bytes)
                 .unwrap();
             srep_msg.add_field(Tag::ROOT, merkle_root).unwrap();
             srep_msg.encode().unwrap()

--- a/src/key/online.rs
+++ b/src/key/online.rs
@@ -21,8 +21,7 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use crate::message::RtMessage;
 use crate::sign::MsgSigner;
 use crate::tag::Tag;
-use crate::version::{Version, BYTES_SUPPORTED_VERSIONS};
-use crate::SIGNED_RESPONSE_CONTEXT;
+use crate::version::Version;
 
 ///
 /// Represents the delegated Roughtime ephemeral online key.
@@ -42,7 +41,7 @@ impl OnlineKey {
     pub fn new() -> Self {
         OnlineKey {
             signer: MsgSigner::new(),
-            supported_versions: BYTES_SUPPORTED_VERSIONS.concat(),
+            supported_versions: Version::supported_versions_wire(),
         }
     }
 
@@ -78,23 +77,28 @@ impl OnlineKey {
 
     /// Create an SREP response containing the provided time and Merkle root,
     /// signed by this online key.
-    pub fn make_srep(&mut self, ver: Version, now: SystemTime, merkle_root: &[u8]) -> RtMessage {
+    pub fn make_srep(
+        &mut self,
+        version: Version,
+        now: SystemTime,
+        merkle_root: &[u8],
+    ) -> RtMessage {
         let mut radi = [0; 4];
         let mut midp = [0; 8];
 
         // RADI is hard coded at 5 seconds (providing a 10-second measurement window overall)
-        let radi_time = match ver {
+        let radi_time = match version {
             Version::Classic => 5_000_000, // five seconds in microseconds
-            Version::Rfc | Version::RfcDraft12 => 5, // five seconds
+            Version::RfcDraft12 => 5,      // five seconds
         };
 
         (&mut radi as &mut [u8])
             .write_u32::<LittleEndian>(radi_time)
             .unwrap();
 
-        let midp_time = match ver {
+        let midp_time = match version {
             Version::Classic => self.classic_midp(now),
-            Version::Rfc | Version::RfcDraft12 => self.rfc_midp(now),
+            Version::RfcDraft12 => self.rfc_midp(now),
         };
 
         (&mut midp as &mut [u8])
@@ -102,7 +106,7 @@ impl OnlineKey {
             .unwrap();
 
         // Signed response SREP
-        let srep_bytes = if ver == Version::Classic {
+        let srep_bytes = if version == Version::Classic {
             let mut srep_msg = RtMessage::with_capacity(3);
             srep_msg.add_field(Tag::RADI, &radi).unwrap();
             srep_msg.add_field(Tag::MIDP, &midp).unwrap();
@@ -110,17 +114,19 @@ impl OnlineKey {
             srep_msg.encode().unwrap()
         } else {
             let mut srep_msg = RtMessage::with_capacity(5);
-            srep_msg.add_field(Tag::VER, ver.wire_bytes()).unwrap();
+            srep_msg.add_field(Tag::VER, version.wire_bytes()).unwrap();
             srep_msg.add_field(Tag::RADI, &radi).unwrap();
             srep_msg.add_field(Tag::MIDP, &midp).unwrap();
-            srep_msg.add_field(Tag::VERS, &self.supported_versions).unwrap();
+            srep_msg
+                .add_field(Tag::VERS, &self.supported_versions)
+                .unwrap();
             srep_msg.add_field(Tag::ROOT, merkle_root).unwrap();
             srep_msg.encode().unwrap()
         };
 
         // signature on SREP
         let srep_signature = {
-            self.signer.update(SIGNED_RESPONSE_CONTEXT.as_bytes());
+            self.signer.update(version.sign_prefix());
             self.signer.update(&srep_bytes);
             self.signer.sign()
         };

--- a/src/key/online.rs
+++ b/src/key/online.rs
@@ -83,7 +83,7 @@ impl OnlineKey {
         // RADI is hard coded at 5 seconds (providing a 10-second measurement window overall)
         let radi_time = match ver {
             Version::Classic => 5_000_000, // five seconds in microseconds
-            Version::Rfc | Version::RfcDraft11 => 5, // five seconds
+            Version::Rfc | Version::RfcDraft12 => 5, // five seconds
         };
 
         (&mut radi as &mut [u8])
@@ -92,7 +92,7 @@ impl OnlineKey {
 
         let midp_time = match ver {
             Version::Classic => self.classic_midp(now),
-            Version::Rfc | Version::RfcDraft11 => self.rfc_midp(now),
+            Version::Rfc | Version::RfcDraft12 => self.rfc_midp(now),
         };
 
         (&mut midp as &mut [u8])

--- a/src/key/online.rs
+++ b/src/key/online.rs
@@ -82,7 +82,7 @@ impl OnlineKey {
 
         // RADI is hard coded at 5 seconds (providing a 10-second measurement window overall)
         let radi_time = match ver {
-            Version::Classic => 5_000_000,           // five seconds in microseconds
+            Version::Classic => 5_000_000, // five seconds in microseconds
             Version::Rfc | Version::RfcDraft11 => 5, // five seconds
         };
 

--- a/src/kms/envelope.rs
+++ b/src/kms/envelope.rs
@@ -134,7 +134,10 @@ impl EnvelopeEncryption {
         let dek_seal_key = LessSafeKey::new(unbound_dek);
 
         // Output overwrites context of 'buf' and appends auth tag to 'buf'
-        if dek_seal_key.seal_in_place_append_tag(nonce, Aad::from(AD), &mut buf).is_err() {
+        if dek_seal_key
+            .seal_in_place_append_tag(nonce, Aad::from(AD), &mut buf)
+            .is_err()
+        {
             return Err(KmsError::OperationFailed(
                 "failed to encrypt plaintext seed".to_string(),
             ));

--- a/src/kms/envelope.rs
+++ b/src/kms/envelope.rs
@@ -134,7 +134,7 @@ impl EnvelopeEncryption {
         let dek_seal_key = LessSafeKey::new(unbound_dek);
 
         // Output overwrites context of 'buf' and appends auth tag to 'buf'
-        if let Err(_) = dek_seal_key.seal_in_place_append_tag(nonce, Aad::from(AD), &mut buf) {
+        if dek_seal_key.seal_in_place_append_tag(nonce, Aad::from(AD), &mut buf).is_err() {
             return Err(KmsError::OperationFailed(
                 "failed to encrypt plaintext seed".to_string(),
             ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,12 +108,6 @@ pub const SEED_LENGTH: u32 = 32;
 /// Size (in bytes) of an Ed25519 signature
 pub const SIGNATURE_LENGTH: u32 = 64;
 
-/// Prefixed to the server's certificate before generating or verifying certificate's signature
-pub const CERTIFICATE_CONTEXT: &str = "RoughTime v1 delegation signature--\x00";
-
-/// Prefixed to the server's response before generating or verifying the server's signature
-pub const SIGNED_RESPONSE_CONTEXT: &str = "RoughTime v1 response signature\x00";
-
 /// Value prepended to leaves prior to hashing
 pub const TREE_LEAF_TWEAK: &[u8] = &[0x00];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub mod stats;
 pub mod version;
 
 /// Version of Roughenough
-pub const VERSION: &str = "1.3.0-draft11";
+pub const VERSION: &str = "1.3.0-draft12";
 
 /// Roughenough version string enriched with any compile-time optional features
 pub fn roughenough_version() -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub mod stats;
 pub mod version;
 
 /// Version of Roughenough
-pub const VERSION: &str = "1.3.0-draft12";
+pub const VERSION: &str = "1.3.0-draft13";
 
 /// Roughenough version string enriched with any compile-time optional features
 pub fn roughenough_version() -> String {

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -17,7 +17,7 @@
 //!
 
 use crate::version::Version;
-use crate::version::Version::{Classic, Rfc, RfcDraft12};
+use crate::version::Version::{Classic, RfcDraft12};
 use ring::digest;
 
 use super::{TREE_LEAF_TWEAK, TREE_NODE_TWEAK};
@@ -43,7 +43,7 @@ impl MerkleTree {
         MerkleTree {
             levels: vec![vec![]],
             algorithm: &digest::SHA512,
-            version: Version::Rfc,
+            version: RfcDraft12,
         }
     }
 
@@ -55,7 +55,7 @@ impl MerkleTree {
         MerkleTree {
             levels: vec![vec![]],
             algorithm: &digest::SHA512,
-            version: Version::Classic,
+            version: Classic,
         }
     }
 
@@ -172,7 +172,7 @@ impl MerkleTree {
     #[inline]
     fn finalize_output(&self, data: Hash) -> Hash {
         match self.version {
-            Rfc | RfcDraft12 => data[0..32].into(),
+            RfcDraft12 => data[0..32].into(),
             Classic => data,
         }
     }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -17,7 +17,7 @@
 //!
 
 use crate::version::Version;
-use crate::version::Version::{Classic, Rfc, RfcDraft11};
+use crate::version::Version::{Classic, Rfc, RfcDraft12};
 use ring::digest;
 
 use super::{TREE_LEAF_TWEAK, TREE_NODE_TWEAK};
@@ -172,7 +172,7 @@ impl MerkleTree {
     #[inline]
     fn finalize_output(&self, data: Hash) -> Hash {
         match self.version {
-            Rfc | RfcDraft11 => data[0..32].into(),
+            Rfc | RfcDraft12 => data[0..32].into(),
             Classic => data,
         }
     }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -37,7 +37,7 @@ pub struct MerkleTree {
 impl MerkleTree {
     ///
     /// Create a new empty Merkle Tree based on SHA-512.
-    /// Output is the 32-bytes (256-bits), SHA-512[0:32]
+    /// Output is the 32-bytes (256-bits), `SHA-512[0:32]`
     ///
     pub fn new_sha512_ietf() -> MerkleTree {
         MerkleTree {

--- a/src/message.rs
+++ b/src/message.rs
@@ -231,7 +231,7 @@ impl RtMessage {
 
     /// Converts the message into a `HashMap` mapping each tag to its value
     pub fn into_hash_map(self) -> HashMap<Tag, Vec<u8>> {
-        self.tags.into_iter().zip(self.values.into_iter()).collect()
+        self.tags.into_iter().zip(self.values).collect()
     }
 
     /// Encode this message into an on-the-wire representation prefixed with RFC framing.
@@ -330,7 +330,7 @@ impl RtMessage {
         for (tag, value) in self.tags.iter().zip(self.values.iter()) {
             result.push_str(&indent2);
             result.push_str(&tag.to_string());
-            result.push_str("(");
+            result.push('(');
             result.push_str(&value.len().to_string());
             result.push_str(") = ");
 
@@ -339,7 +339,7 @@ impl RtMessage {
                 result.push_str(&nested_msg.to_string(indent_level + 1))
             } else {
                 result.push_str(&HEX.encode(value));
-                result.push_str("\n");
+                result.push('\n');
             }
         }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -532,8 +532,7 @@ mod test {
     fn from_bytes_offset_past_end_of_message() {
         let mut msg = RtMessage::with_capacity(2);
         msg.add_field(Tag::NONC, "1111".as_bytes()).unwrap();
-        msg.add_field(Tag::PAD, "aaaaaaaaa".as_bytes())
-            .unwrap();
+        msg.add_field(Tag::PAD, "aaaaaaaaa".as_bytes()).unwrap();
 
         let mut bytes = msg.encode().unwrap();
         // set the PAD value offset to beyond end of the message

--- a/src/message.rs
+++ b/src/message.rs
@@ -154,13 +154,15 @@ impl RtMessage {
         // as an offset from the end of the header
         let msg_end = bytes.len() - header_end;
 
+        // Create an iterator for the offset pairs of each tag value
+        let start_offsets = once(&0).chain(offsets.iter());
+        let end_offsets = offsets.iter().chain(once(&msg_end));
+        let offset_pairs = start_offsets.zip(end_offsets);
+
+        // The message being built
         let mut rt_msg = RtMessage::with_capacity(num_tags);
 
-        for (tag, (value_start, value_end)) in tags.into_iter().zip(
-            once(&0)
-                .chain(offsets.iter())
-                .zip(offsets.iter().chain(once(&msg_end))),
-        ) {
+        for (tag, (value_start, value_end)) in tags.into_iter().zip(offset_pairs) {
             let start_idx = header_end + value_start;
             let end_idx = header_end + value_end;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -85,7 +85,7 @@ fn nonce_from_rfc_request(buf: &[u8], expected_srv: &[u8]) -> Result<(Vec<u8>, V
 }
 
 fn get_supported_version(msg: &RtMessage) -> Option<Version> {
-    const SUPPORTED_VERSIONS: &[Version] = &[Version::RfcDraft12, Version::Rfc];
+    const SUPPORTED_VERSIONS: &[Version] = &[Version::RfcDraft12];
 
     if let Some(tag_bytes) = msg.get_field(Tag::VER) {
         // Iterate the list of supplied versions, looking for the first match

--- a/src/request.rs
+++ b/src/request.rs
@@ -22,11 +22,15 @@ use crate::version::Version;
 use crate::{Error, RtMessage, Tag, MAX_REQUEST_LENGTH, MIN_REQUEST_LENGTH, REQUEST_FRAMING_BYTES};
 
 /// Guess which protocol the request is using and extract the client's nonce from the request
-pub fn nonce_from_request(buf: &[u8], num_bytes: usize, expected_srv: &[u8]) -> Result<(Vec<u8>, Version), Error> {
+pub fn nonce_from_request(
+    buf: &[u8],
+    num_bytes: usize,
+    expected_srv: &[u8],
+) -> Result<(Vec<u8>, Version), Error> {
     if num_bytes < MIN_REQUEST_LENGTH {
-        return Err(Error::RequestTooShort)
+        return Err(Error::RequestTooShort);
     } else if num_bytes > MAX_REQUEST_LENGTH {
-        return Err(Error::RequestTooLarge)
+        return Err(Error::RequestTooLarge);
     }
 
     if is_classic_request(buf) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -85,7 +85,7 @@ fn nonce_from_rfc_request(buf: &[u8], expected_srv: &[u8]) -> Result<(Vec<u8>, V
 }
 
 fn get_supported_version(msg: &RtMessage) -> Option<Version> {
-    const SUPPORTED_VERSIONS: &[Version] = &[Version::RfcDraft11, Version::Rfc];
+    const SUPPORTED_VERSIONS: &[Version] = &[Version::RfcDraft12, Version::Rfc];
 
     if let Some(tag_bytes) = msg.get_field(Tag::VER) {
         // Iterate the list of supplied versions, looking for the first match

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -25,13 +25,12 @@ use data_encoding::{Encoding, HEXLOWER_PERMISSIVE};
 use mio::net::UdpSocket;
 
 use crate::config::ServerConfig;
-use crate::error::Error::SendingResponseFailed;
 use crate::grease::Grease;
 use crate::key::{LongTermKey, OnlineKey};
 use crate::merkle::MerkleTree;
 use crate::stats::ServerStats;
 use crate::version::Version;
-use crate::{Error, RtMessage, Tag};
+use crate::{RtMessage, Tag};
 
 const HEX: Encoding = HEXLOWER_PERMISSIVE;
 

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -115,7 +115,7 @@ impl Responder {
 
             let resp_bytes = match self.version {
                 Version::Classic => resp_msg.encode().unwrap(),
-                Version::Rfc | Version::RfcDraft11 => resp_msg.encode_framed().unwrap(),
+                Version::Rfc | Version::RfcDraft12 => resp_msg.encode_framed().unwrap(),
             };
 
             let mut bytes_sent: usize = 0;
@@ -139,7 +139,7 @@ impl Responder {
             if successful_send {
                 match self.version {
                     Version::Classic => stats.add_classic_response(&src_addr.ip(), bytes_sent),
-                    Version::Rfc | Version::RfcDraft11 => {
+                    Version::Rfc | Version::RfcDraft12 => {
                         stats.add_rfc_response(&src_addr.ip(), bytes_sent)
                     }
                 }

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -102,7 +102,7 @@ impl Responder {
             .online_key
             .make_srep(self.version, SystemTime::now(), &merkle_root);
 
-        for (idx, &(ref nonce, ref src_addr)) in self.requests.iter().enumerate() {
+        for (idx, (nonce, src_addr)) in self.requests.iter().enumerate() {
             let paths = self.merkle.get_paths(idx);
             let resp_msg = {
                 let r = self.make_response(&srep, &self.cert_bytes, &paths, idx as u32);
@@ -121,7 +121,7 @@ impl Responder {
             let mut bytes_sent: usize = 0;
             let mut successful_send: bool = true;
 
-            match socket.send_to(&resp_bytes, &src_addr) {
+            match socket.send_to(&resp_bytes, src_addr) {
                 Ok(num_bytes) => bytes_sent = num_bytes,
                 Err(_) => successful_send = false,
             }

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -166,13 +166,6 @@ impl Responder {
 
         let mut response = RtMessage::with_capacity(6);
         response.add_field(Tag::SIG, sig_bytes).unwrap();
-
-        if self.version != Version::Classic {
-            response
-                .add_field(Tag::VER, self.version.wire_bytes())
-                .unwrap();
-        }
-
         response.add_field(Tag::PATH, path).unwrap();
         response.add_field(Tag::SREP, srep_bytes).unwrap();
         response.add_field(Tag::CERT, cert_bytes).unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -90,8 +90,13 @@ impl Server {
         let poll = Poll::new().unwrap();
         poll.register(&socket, EVT_MESSAGE, Ready::readable(), PollOpt::edge())
             .unwrap();
-        poll.register(&timer, EVT_STATUS_UPDATE, Ready::readable(), PollOpt::edge())
-            .unwrap();
+        poll.register(
+            &timer,
+            EVT_STATUS_UPDATE,
+            Ready::readable(),
+            PollOpt::edge(),
+        )
+        .unwrap();
 
         let health_listener = if let Some(hc_port) = config.health_check_port() {
             let hc_sock_addr: SocketAddr = format!("{}:{}", config.interface(), hc_port)
@@ -101,8 +106,13 @@ impl Server {
             let tcp_listener = TcpListener::bind(&hc_sock_addr)
                 .expect("failed to bind TCP listener for health check");
 
-            poll.register(&tcp_listener, EVT_HEALTH_CHECK, Ready::readable(), PollOpt::edge())
-                .unwrap();
+            poll.register(
+                &tcp_listener,
+                EVT_HEALTH_CHECK,
+                Ready::readable(),
+                PollOpt::edge(),
+            )
+            .unwrap();
 
             Some(tcp_listener)
         } else {
@@ -274,10 +284,7 @@ impl Server {
     fn send_client_stats(&mut self) {
         let start = Instant::now();
 
-        let clients: Vec<ClientStats> = self.stats_recorder
-            .iter()
-            .map(|(_, s)| *s)
-            .collect();
+        let clients: Vec<ClientStats> = self.stats_recorder.iter().map(|(_, s)| *s).collect();
 
         let client_count = clients.len();
         if client_count > 0 {
@@ -291,7 +298,9 @@ impl Server {
         let elapsed = start.elapsed();
         info!(
             "{} enqueued {} client stats in {:.3} seconds",
-            self.thread_name(), client_count, elapsed.as_secs_f32()
+            self.thread_name(),
+            client_count,
+            elapsed.as_secs_f32()
         );
     }
 
@@ -324,8 +333,14 @@ mod test {
 
     #[test]
     fn no_jitter_when_duration_lt_1sec() {
-        assert_eq!(Server::compute_delay(Duration::from_millis(999)), Duration::from_millis(999));
-        assert_eq!(Server::compute_delay(Duration::from_millis(500)), Duration::from_millis(500));
+        assert_eq!(
+            Server::compute_delay(Duration::from_millis(999)),
+            Duration::from_millis(999)
+        );
+        assert_eq!(
+            Server::compute_delay(Duration::from_millis(500)),
+            Duration::from_millis(500)
+        );
     }
 
     #[test]
@@ -344,6 +359,6 @@ mod test {
             } else {
                 assert!(computed - base < limit);
             }
-        };
+        }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -72,7 +72,7 @@ pub struct Server {
     stats_queue: Arc<StatsQueue>,
 
     // Used to send requests to ourselves in fuzzing mode
-    #[cfg(fuzzing)]
+    #[cfg(feature = "fuzzing")]
     fake_client_socket: UdpSocket,
 }
 
@@ -146,7 +146,7 @@ impl Server {
             stats_recorder: stats,
             stats_queue: queue,
 
-            #[cfg(fuzzing)]
+            #[cfg(feature = "fuzzing")]
             fake_client_socket: UdpSocket::bind(&"127.0.0.1:0".parse().unwrap()).unwrap(),
         }
     }
@@ -156,7 +156,7 @@ impl Server {
         self.responder_rfc.get_public_key()
     }
 
-    #[cfg(fuzzing)]
+    #[cfg(feature = "fuzzing")]
     pub fn send_to_self(&mut self, data: &[u8]) {
         let res = self
             .fake_client_socket

--- a/src/server.rs
+++ b/src/server.rs
@@ -278,6 +278,10 @@ impl Server {
             .collect();
 
         let client_count = clients.len();
+        if client_count == 0 {
+            debug!("{} 0 client stats", self.thread_name());
+            return;
+        }
 
         self.stats_queue.force_push(clients);
         self.stats_recorder.clear();

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,7 +19,6 @@
 use std::io::ErrorKind;
 use std::io::Write;
 use std::net::{Shutdown, SocketAddr};
-use std::ops::Div;
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -154,7 +153,7 @@ impl Server {
 
     /// Returns a reference to the server's long-term public key
     pub fn get_public_key(&self) -> &str {
-        &self.responder_rfc.get_public_key()
+        self.responder_rfc.get_public_key()
     }
 
     #[cfg(fuzzing)]
@@ -253,7 +252,7 @@ impl Server {
                 info!("health check from {}", src_addr);
                 self.stats_recorder.add_health_check(&src_addr.ip());
 
-                match stream.write(HTTP_RESPONSE.as_bytes()) {
+                match stream.write_all(HTTP_RESPONSE.as_bytes()) {
                     Ok(_) => (),
                     Err(e) => warn!("error writing health check {}", e),
                 };
@@ -277,7 +276,7 @@ impl Server {
 
         let clients: Vec<ClientStats> = self.stats_recorder
             .iter()
-            .map(|(_, s)| s.clone())
+            .map(|(_, s)| *s)
             .collect();
 
         let client_count = clients.len();

--- a/src/server.rs
+++ b/src/server.rs
@@ -131,7 +131,7 @@ impl Server {
         };
 
         let responder_rfc = Responder::new(Version::Rfc, config, &mut long_term_key);
-        let responder_draft = Responder::new(Version::RfcDraft11, config, &mut long_term_key);
+        let responder_draft = Responder::new(Version::RfcDraft12, config, &mut long_term_key);
         let responder_classic = Responder::new(Version::Classic, config, &mut long_term_key);
 
         let batch_size = config.batch_size();
@@ -221,7 +221,7 @@ impl Server {
                             self.stats_recorder.add_rfc_request(&src_addr.ip());
                         }
                         // TODO(stuart) remove when RFC is ratified
-                        Ok((nonce, Version::RfcDraft11)) => {
+                        Ok((nonce, Version::RfcDraft12)) => {
                             self.responder_draft.add_request(nonce, src_addr);
                             // Mismatch of draft responder vs rfc stats is intentional
                             self.stats_recorder.add_rfc_request(&src_addr.ip());

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -50,10 +50,7 @@ impl MsgVerifier {
 
     pub fn verify(&self, provided_sig: &[u8]) -> bool {
         let sig = Signature::from_slice(provided_sig).expect("valid signature");
-        match self.pubkey.verify(&self.buf, &sig) {
-            Ok(_) => true,
-            _ => false,
-        }
+        self.pubkey.verify(&self.buf, &sig).is_ok()
     }
 }
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -20,9 +20,9 @@ use std::fmt;
 use std::fmt::Formatter;
 
 use data_encoding::{Encoding, HEXLOWER_PERMISSIVE};
-use ed25519_dalek::{SigningKey, Signature, Verifier, Signer, VerifyingKey, SecretKey};
-use ring::rand::SecureRandom;
+use ed25519_dalek::{SecretKey, Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use ring::rand;
+use ring::rand::SecureRandom;
 
 const HEX: Encoding = HEXLOWER_PERMISSIVE;
 

--- a/src/stats/aggregated.rs
+++ b/src/stats/aggregated.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::stats::ClientStatEntry;
+use crate::stats::ClientStats;
 use crate::stats::ServerStats;
 use crate::Error;
 use std::collections::hash_map::Iter;
@@ -34,7 +34,7 @@ pub struct AggregatedStats {
     bytes_sent: usize,
     send_failed_attempts: u64,
     send_retry_attempts: u64,
-    empty_map: HashMap<IpAddr, ClientStatEntry>,
+    empty_map: HashMap<IpAddr, ClientStats>,
 }
 
 impl Default for AggregatedStats {
@@ -144,11 +144,11 @@ impl ServerStats for AggregatedStats {
         0
     }
 
-    fn stats_for_client(&self, _addr: &IpAddr) -> Option<&ClientStatEntry> {
+    fn stats_for_client(&self, _addr: &IpAddr) -> Option<&ClientStats> {
         None
     }
 
-    fn iter(&self) -> Iter<IpAddr, ClientStatEntry> {
+    fn iter(&self) -> Iter<IpAddr, ClientStats> {
         self.empty_map.iter()
     }
 

--- a/src/stats/aggregated.rs
+++ b/src/stats/aggregated.rs
@@ -62,7 +62,7 @@ impl AggregatedStats {
 }
 
 impl ServerStats for AggregatedStats {
-    fn add_rfc_request(&mut self, _: &IpAddr) {
+    fn add_ietf_request(&mut self, _: &IpAddr) {
         self.rfc_requests += 1
     }
 

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -20,12 +20,12 @@ pub use crate::stats::aggregated::AggregatedStats;
 pub use crate::stats::per_client::PerClientStats;
 pub use crate::stats::reporter::Reporter;
 use crate::Error;
+use chrono::Utc;
 use crossbeam_queue::ArrayQueue;
 use serde::Serialize;
 use std::cmp;
 use std::collections::hash_map::Iter;
 use std::net::IpAddr;
-use std::time::SystemTime;
 
 mod aggregated;
 mod per_client;
@@ -48,7 +48,7 @@ pub struct ClientStats {
     pub failed_send_attempts: u32,
     pub retried_send_attempts: u32,
     pub ip_addr: IpAddr,
-    pub first_seen: SystemTime,
+    pub first_seen: i64,
 }
 
 impl ClientStats {
@@ -64,7 +64,7 @@ impl ClientStats {
             failed_send_attempts: 0,
             retried_send_attempts: 0,
             ip_addr: ip_addr,
-            first_seen: SystemTime::now(),
+            first_seen: Utc::now().timestamp(),
         }
     }
 

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -67,7 +67,7 @@ impl ClientStats {
             failed_send_attempts: 0,
             retried_send_attempts: 0,
             first_seen: Utc::now().timestamp(),
-            ip_addr: ip_addr,
+            ip_addr,
         }
     }
 

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -22,7 +22,7 @@ pub use crate::stats::reporter::Reporter;
 use crate::Error;
 use chrono::Utc;
 use crossbeam_queue::ArrayQueue;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::cmp;
 use std::collections::hash_map::Iter;
 use std::net::IpAddr;
@@ -39,11 +39,12 @@ pub const MAX_CLIENTS: usize = 4_000_000;
 ///
 /// Specific metrics tracked per each client
 ///
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct ClientStats {
     pub rfc_requests: u32,
     pub classic_requests: u32,
     pub invalid_requests: u32,
+    pub health_checks: u32,
     pub rfc_responses_sent: u32,
     pub classic_responses_sent: u32,
     pub bytes_sent: usize,
@@ -59,6 +60,7 @@ impl ClientStats {
             rfc_requests: 0,
             classic_requests: 0,
             invalid_requests: 0,
+            health_checks: 0,
             rfc_responses_sent: 0,
             classic_responses_sent: 0,
             bytes_sent: 0,
@@ -76,6 +78,7 @@ impl ClientStats {
         self.rfc_requests += other.rfc_requests;
         self.classic_requests += other.classic_requests;
         self.invalid_requests += other.invalid_requests;
+        self.health_checks += other.health_checks;
         self.rfc_responses_sent += other.rfc_responses_sent;
         self.classic_responses_sent += other.classic_responses_sent;
         self.bytes_sent += other.bytes_sent;

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -34,7 +34,7 @@ mod reporter;
 pub type StatsQueue = ArrayQueue<Vec<ClientStats>>;
 
 /// Maximum number of tracked clients to prevent DoS and unbounded memory growth.
-pub const MAX_CLIENTS: usize = 4_000_000;
+pub const MAX_CLIENTS: usize = 5_000_000;
 
 ///
 /// Specific metrics tracked per each client
@@ -50,8 +50,8 @@ pub struct ClientStats {
     pub bytes_sent: usize,
     pub failed_send_attempts: u32,
     pub retried_send_attempts: u32,
-    pub ip_addr: IpAddr,
     pub first_seen: i64,
+    pub ip_addr: IpAddr,
 }
 
 impl ClientStats {
@@ -66,8 +66,8 @@ impl ClientStats {
             bytes_sent: 0,
             failed_send_attempts: 0,
             retried_send_attempts: 0,
-            ip_addr: ip_addr,
             first_seen: Utc::now().timestamp(),
+            ip_addr: ip_addr,
         }
     }
 

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -33,6 +33,9 @@ mod reporter;
 
 pub type StatsQueue = ArrayQueue<Vec<ClientStats>>;
 
+/// Maximum number of tracked clients to prevent DoS and unbounded memory growth.
+pub const MAX_CLIENTS: usize = 4_000_000;
+
 ///
 /// Specific metrics tracked per each client
 ///

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -22,7 +22,7 @@ pub use crate::stats::reporter::Reporter;
 use crate::Error;
 use chrono::Utc;
 use crossbeam_queue::ArrayQueue;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::collections::hash_map::Iter;
 use std::net::IpAddr;
@@ -39,12 +39,11 @@ pub const MAX_CLIENTS: usize = 4_000_000;
 ///
 /// Specific metrics tracked per each client
 ///
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ClientStats {
     pub rfc_requests: u32,
     pub classic_requests: u32,
     pub invalid_requests: u32,
-    pub health_checks: u32,
     pub rfc_responses_sent: u32,
     pub classic_responses_sent: u32,
     pub bytes_sent: usize,
@@ -60,7 +59,6 @@ impl ClientStats {
             rfc_requests: 0,
             classic_requests: 0,
             invalid_requests: 0,
-            health_checks: 0,
             rfc_responses_sent: 0,
             classic_responses_sent: 0,
             bytes_sent: 0,
@@ -78,7 +76,6 @@ impl ClientStats {
         self.rfc_requests += other.rfc_requests;
         self.classic_requests += other.classic_requests;
         self.invalid_requests += other.invalid_requests;
-        self.health_checks += other.health_checks;
         self.rfc_responses_sent += other.rfc_responses_sent;
         self.classic_responses_sent += other.classic_responses_sent;
         self.bytes_sent += other.bytes_sent;

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -92,7 +92,7 @@ impl ClientStats {
 /// Implementations of this trait record client activity
 ///
 pub trait ServerStats {
-    fn add_rfc_request(&mut self, addr: &IpAddr);
+    fn add_ietf_request(&mut self, addr: &IpAddr);
 
     fn add_classic_request(&mut self, addr: &IpAddr);
 
@@ -171,7 +171,7 @@ mod test {
         stats.add_classic_request(&ip1);
         stats.add_classic_request(&ip2);
         stats.add_classic_request(&ip3);
-        stats.add_rfc_request(&ip3);
+        stats.add_ietf_request(&ip3);
         assert_eq!(stats.total_valid_requests(), 4);
         assert_eq!(stats.num_classic_requests(), 3);
         assert_eq!(stats.num_rfc_requests(), 1);

--- a/src/stats/per_client.rs
+++ b/src/stats/per_client.rs
@@ -75,7 +75,7 @@ impl PerClientStats {
 }
 
 impl ServerStats for PerClientStats {
-    fn add_rfc_request(&mut self, addr: &IpAddr) {
+    fn add_ietf_request(&mut self, addr: &IpAddr) {
         if self.too_many_entries() {
             return;
         }

--- a/src/stats/per_client.rs
+++ b/src/stats/per_client.rs
@@ -125,8 +125,14 @@ impl ServerStats for PerClientStats {
             .retried_send_attempts += 1;
     }
 
-    fn add_health_check(&mut self, _: &IpAddr) {
-        // no-op
+    fn add_health_check(&mut self, addr: &IpAddr) {
+        if self.too_many_entries() {
+            return;
+        }
+        self.clients
+            .entry(*addr)
+            .or_insert_with_key(|addr| ClientStats::new(addr.clone()))
+            .health_checks += 1;
     }
 
     fn add_rfc_response(&mut self, addr: &IpAddr, bytes_sent: usize) {
@@ -180,7 +186,9 @@ impl ServerStats for PerClientStats {
     }
 
     fn total_health_checks(&self) -> u64 {
-        0
+        self.clients.values()
+            .map(|&v| v.health_checks as u64)
+            .sum()
     }
 
     fn total_failed_send_attempts(&self) -> u64 {

--- a/src/stats/per_client.rs
+++ b/src/stats/per_client.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::stats::{ClientStats, MAX_CLIENTS};
 use crate::stats::ServerStats;
+use crate::stats::{ClientStats, MAX_CLIENTS};
 use crate::Error;
 use std::collections::hash_map::Iter;
 use std::collections::HashMap;
@@ -162,43 +162,44 @@ impl ServerStats for PerClientStats {
     }
 
     fn total_valid_requests(&self) -> u64 {
-        self.clients.values()
+        self.clients
+            .values()
             .map(|&v| v.rfc_requests as u64 + v.classic_requests as u64)
             .sum()
     }
 
     fn num_rfc_requests(&self) -> u64 {
-        self.clients.values()
-            .map(|&v| v.rfc_requests as u64)
-            .sum()
+        self.clients.values().map(|&v| v.rfc_requests as u64).sum()
     }
 
     fn num_classic_requests(&self) -> u64 {
-        self.clients.values()
+        self.clients
+            .values()
             .map(|&v| v.classic_requests as u64)
             .sum()
     }
 
     fn total_invalid_requests(&self) -> u64 {
-        self.clients.values()
+        self.clients
+            .values()
             .map(|&v| v.invalid_requests as u64)
             .sum()
     }
 
     fn total_health_checks(&self) -> u64 {
-        self.clients.values()
-            .map(|&v| v.health_checks as u64)
-            .sum()
+        self.clients.values().map(|&v| v.health_checks as u64).sum()
     }
 
     fn total_failed_send_attempts(&self) -> u64 {
-        self.clients.values()
+        self.clients
+            .values()
             .map(|&v| v.failed_send_attempts as u64)
             .sum()
     }
 
     fn total_retried_send_attempts(&self) -> u64 {
-        self.clients.values()
+        self.clients
+            .values()
             .map(|&v| v.retried_send_attempts as u64)
             .sum()
     }
@@ -212,7 +213,8 @@ impl ServerStats for PerClientStats {
     }
 
     fn num_rfc_responses_sent(&self) -> u64 {
-        self.clients.values()
+        self.clients
+            .values()
             .map(|&v| v.rfc_responses_sent as u64)
             .sum()
     }
@@ -226,9 +228,7 @@ impl ServerStats for PerClientStats {
     }
 
     fn total_bytes_sent(&self) -> usize {
-        self.clients.values()
-            .map(|&v| v.bytes_sent)
-            .sum()
+        self.clients.values().map(|&v| v.bytes_sent).sum()
     }
 
     fn total_unique_clients(&self) -> u64 {

--- a/src/stats/per_client.rs
+++ b/src/stats/per_client.rs
@@ -165,56 +165,73 @@ impl ServerStats for PerClientStats {
     }
 
     fn total_valid_requests(&self) -> u64 {
-        self.clients
-            .values()
-            .map(|&v| v.rfc_requests + v.classic_requests)
+        self.clients.values()
+            .map(|&v| v.rfc_requests as u64 + v.classic_requests as u64)
             .sum()
     }
 
     fn num_rfc_requests(&self) -> u64 {
-        self.clients.values().map(|&v| v.rfc_requests).sum()
+        self.clients.values()
+            .map(|&v| v.rfc_requests as u64)
+            .sum()
     }
 
     fn num_classic_requests(&self) -> u64 {
-        self.clients.values().map(|&v| v.classic_requests).sum()
+        self.clients.values()
+            .map(|&v| v.classic_requests as u64)
+            .sum()
     }
 
     fn total_invalid_requests(&self) -> u64 {
-        self.clients.values().map(|&v| v.invalid_requests).sum()
+        self.clients.values()
+            .map(|&v| v.invalid_requests as u64)
+            .sum()
     }
 
     fn total_health_checks(&self) -> u64 {
-        self.clients.values().map(|&v| v.health_checks).sum()
+        self.clients.values()
+            .map(|&v| v.health_checks as u64)
+            .sum()
     }
 
     fn total_failed_send_attempts(&self) -> u64 {
-        self.clients.values().map(|&v| v.failed_send_attempts).sum()
+        self.clients.values()
+            .map(|&v| v.failed_send_attempts as u64)
+            .sum()
     }
 
     fn total_retried_send_attempts(&self) -> u64 {
-        self.clients.values().map(|&v| v.retried_send_attempts).sum()
+        self.clients.values()
+            .map(|&v| v.retried_send_attempts as u64)
+            .sum()
     }
 
     fn total_responses_sent(&self) -> u64 {
         self.clients
             .values()
             .map(|&v| v.rfc_responses_sent + v.classic_responses_sent)
+            .map(|v| v as u64)
             .sum()
     }
 
     fn num_rfc_responses_sent(&self) -> u64 {
-        self.clients.values().map(|&v| v.rfc_responses_sent).sum()
+        self.clients.values()
+            .map(|&v| v.rfc_responses_sent as u64)
+            .sum()
     }
 
     fn num_classic_responses_sent(&self) -> u64 {
         self.clients
             .values()
             .map(|&v| v.classic_responses_sent)
+            .map(|v| v as u64)
             .sum()
     }
 
     fn total_bytes_sent(&self) -> usize {
-        self.clients.values().map(|&v| v.bytes_sent).sum()
+        self.clients.values()
+            .map(|&v| v.bytes_sent)
+            .sum()
     }
 
     fn total_unique_clients(&self) -> u64 {

--- a/src/stats/per_client.rs
+++ b/src/stats/per_client.rs
@@ -125,14 +125,8 @@ impl ServerStats for PerClientStats {
             .retried_send_attempts += 1;
     }
 
-    fn add_health_check(&mut self, addr: &IpAddr) {
-        if self.too_many_entries() {
-            return;
-        }
-        self.clients
-            .entry(*addr)
-            .or_insert_with_key(|addr| ClientStats::new(addr.clone()))
-            .health_checks += 1;
+    fn add_health_check(&mut self, _: &IpAddr) {
+        // no-op
     }
 
     fn add_rfc_response(&mut self, addr: &IpAddr, bytes_sent: usize) {
@@ -186,9 +180,7 @@ impl ServerStats for PerClientStats {
     }
 
     fn total_health_checks(&self) -> u64 {
-        self.clients.values()
-            .map(|&v| v.health_checks as u64)
-            .sum()
+        0
     }
 
     fn total_failed_send_attempts(&self) -> u64 {

--- a/src/stats/per_client.rs
+++ b/src/stats/per_client.rs
@@ -15,8 +15,8 @@
 use crate::stats::ServerStats;
 use crate::stats::{ClientStats, MAX_CLIENTS};
 use crate::Error;
+use ahash::AHashMap;
 use std::collections::hash_map::Iter;
-use std::collections::HashMap;
 use std::net::IpAddr;
 
 ///
@@ -27,7 +27,7 @@ use std::net::IpAddr;
 /// and `num_overflows` is incremented.
 ///
 pub struct PerClientStats {
-    clients: HashMap<IpAddr, ClientStats>,
+    clients: AHashMap<IpAddr, ClientStats>,
     num_overflows: u64,
     max_clients: usize,
 }
@@ -41,7 +41,7 @@ impl Default for PerClientStats {
 impl PerClientStats {
     pub fn new() -> Self {
         PerClientStats {
-            clients: HashMap::with_capacity(MAX_CLIENTS),
+            clients: AHashMap::with_capacity(MAX_CLIENTS),
             num_overflows: 0,
             max_clients: MAX_CLIENTS,
         }
@@ -51,7 +51,7 @@ impl PerClientStats {
     #[cfg(test)]
     pub fn with_limit(limit: usize) -> Self {
         PerClientStats {
-            clients: HashMap::with_capacity(limit),
+            clients: AHashMap::with_capacity(limit),
             num_overflows: 0,
             max_clients: limit,
         }

--- a/src/stats/per_client.rs
+++ b/src/stats/per_client.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::stats::ClientStats;
+use crate::stats::{ClientStats, MAX_CLIENTS};
 use crate::stats::ServerStats;
 use crate::Error;
 use std::collections::hash_map::Iter;
@@ -37,10 +37,6 @@ impl Default for PerClientStats {
         Self::new()
     }
 }
-
-/// Maximum number of entries to prevent DoS and unbounded memory growth.
-/// This is effectively the entire IPv4 address space.
-pub const MAX_CLIENTS: usize = u32::MAX as usize;
 
 impl PerClientStats {
     pub fn new() -> Self {

--- a/src/stats/per_client.rs
+++ b/src/stats/per_client.rs
@@ -81,7 +81,7 @@ impl ServerStats for PerClientStats {
         }
         self.clients
             .entry(*addr)
-            .or_insert_with_key(|addr| ClientStats::new(addr.clone()))
+            .or_insert_with_key(|addr| ClientStats::new(*addr))
             .rfc_requests += 1;
     }
 
@@ -91,7 +91,7 @@ impl ServerStats for PerClientStats {
         }
         self.clients
             .entry(*addr)
-            .or_insert_with_key(|addr| ClientStats::new(addr.clone()))
+            .or_insert_with_key(|addr| ClientStats::new(*addr))
             .classic_requests += 1;
     }
 
@@ -101,7 +101,7 @@ impl ServerStats for PerClientStats {
         }
         self.clients
             .entry(*addr)
-            .or_insert_with_key(|addr| ClientStats::new(addr.clone()))
+            .or_insert_with_key(|addr| ClientStats::new(*addr))
             .invalid_requests += 1;
     }
 
@@ -111,7 +111,7 @@ impl ServerStats for PerClientStats {
         }
         self.clients
             .entry(*addr)
-            .or_insert_with_key(|addr| ClientStats::new(addr.clone()))
+            .or_insert_with_key(|addr| ClientStats::new(*addr))
             .failed_send_attempts += 1;
     }
 
@@ -121,7 +121,7 @@ impl ServerStats for PerClientStats {
         }
         self.clients
             .entry(*addr)
-            .or_insert_with_key(|addr| ClientStats::new(addr.clone()))
+            .or_insert_with_key(|addr| ClientStats::new(*addr))
             .retried_send_attempts += 1;
     }
 
@@ -131,7 +131,7 @@ impl ServerStats for PerClientStats {
         }
         self.clients
             .entry(*addr)
-            .or_insert_with_key(|addr| ClientStats::new(addr.clone()))
+            .or_insert_with_key(|addr| ClientStats::new(*addr))
             .health_checks += 1;
     }
 
@@ -142,7 +142,7 @@ impl ServerStats for PerClientStats {
         let entry = self
             .clients
             .entry(*addr)
-            .or_insert_with_key(|addr| ClientStats::new(addr.clone()));
+            .or_insert_with_key(|addr| ClientStats::new(*addr));
 
         entry.rfc_responses_sent += 1;
         entry.bytes_sent += bytes_sent;
@@ -155,7 +155,7 @@ impl ServerStats for PerClientStats {
         let entry = self
             .clients
             .entry(*addr)
-            .or_insert_with_key(|addr| ClientStats::new(addr.clone()));
+            .or_insert_with_key(|addr| ClientStats::new(*addr));
 
         entry.classic_responses_sent += 1;
         entry.bytes_sent += bytes_sent;

--- a/src/stats/per_client.rs
+++ b/src/stats/per_client.rs
@@ -39,7 +39,8 @@ impl Default for PerClientStats {
 }
 
 /// Maximum number of entries to prevent DoS and unbounded memory growth.
-pub const MAX_CLIENTS: usize = 100_000;
+/// This is effectively the entire IPv4 address space.
+pub const MAX_CLIENTS: usize = u32::MAX as usize;
 
 impl PerClientStats {
     pub fn new() -> Self {

--- a/src/stats/reporter.rs
+++ b/src/stats/reporter.rs
@@ -16,7 +16,7 @@
 //! Coalesces client statistics from all workers and persists aggregated data.
 //!
 
-use crate::stats::{ClientStats, StatsQueue};
+use crate::stats::{ClientStats, StatsQueue, MAX_CLIENTS};
 use chrono::Utc;
 use csv::WriterBuilder;
 use std::collections::HashMap;
@@ -26,8 +26,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
-
-static MAX_CLIENTS: usize = u32::MAX as usize;
 
 pub struct Reporter {
     source_queue: Arc<StatsQueue>,

--- a/src/stats/reporter.rs
+++ b/src/stats/reporter.rs
@@ -1,0 +1,84 @@
+// Copyright 2017-2024 int08h LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//!
+//! Coalesces client statistics from all workers and persists aggregated data.
+//!
+
+use crate::stats::{ClientStats, StatsQueue};
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::io::{Error, ErrorKind};
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+static MAX_CLIENTS: usize = 256_000;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+struct Client {
+    ip_addr: IpAddr,
+    last_seen: Instant,
+    first_seen: Instant,
+}
+
+// Implement Ord to make our priority queue a min-heap instead of default max-heap
+impl Ord for Client {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.last_seen
+            .cmp(&self.last_seen)
+            .then_with(|| self.first_seen.cmp(&other.first_seen))
+    }
+}
+
+impl PartialOrd for Client {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub struct Reporter {
+    source_queue: Arc<StatsQueue>,
+    client_stats: HashMap<IpAddr, ClientStats>,
+    last_update: Instant,
+    report_interval: Duration,
+    output_location: PathBuf,
+}
+
+impl Reporter {
+
+    pub fn new(source_queue: Arc<StatsQueue>, output_location: &Path, report_interval: &Duration) -> Result<Reporter, Error> {
+        if !output_location.is_dir() {
+            return Err(Error::new(ErrorKind::InvalidInput, "output location is not a directory"));
+        }
+
+        if output_location.metadata()?.permissions().readonly() {
+            return Err(Error::new(ErrorKind::PermissionDenied, "output location is readonly"));
+        }
+
+        if report_interval.is_zero() || report_interval.as_secs() < 1 {
+            return Err(Error::new(ErrorKind::InvalidInput, "report interval invalid"));
+        }
+
+        Ok(Reporter {
+            source_queue,
+            client_stats: HashMap::with_capacity(MAX_CLIENTS),
+            last_update: Instant::now(),
+            report_interval: report_interval.clone(),
+            output_location: output_location.to_path_buf(),
+        })
+    }
+
+}

--- a/src/stats/reporter.rs
+++ b/src/stats/reporter.rs
@@ -27,7 +27,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-static MAX_CLIENTS: usize = 256_000;
+static MAX_CLIENTS: usize = u32::MAX as usize;
 
 pub struct Reporter {
     source_queue: Arc<StatsQueue>,

--- a/src/stats/reporter.rs
+++ b/src/stats/reporter.rs
@@ -17,9 +17,9 @@
 //!
 
 use crate::stats::{ClientStats, StatsQueue, MAX_CLIENTS};
+use ahash::AHashMap;
 use chrono::Utc;
 use csv;
-use std::collections::HashMap;
 use std::fs::File;
 use std::net::IpAddr;
 use std::path::PathBuf;
@@ -30,7 +30,7 @@ use std::time::{Duration, Instant};
 
 pub struct Reporter {
     source_queue: Arc<StatsQueue>,
-    client_stats: HashMap<IpAddr, ClientStats>,
+    client_stats: AHashMap<IpAddr, ClientStats>,
     next_update: Instant,
     report_interval: Duration,
     output_location: Option<PathBuf>,
@@ -44,7 +44,7 @@ impl Reporter {
     ) -> Reporter {
         Reporter {
             source_queue,
-            client_stats: HashMap::with_capacity(MAX_CLIENTS),
+            client_stats: AHashMap::with_capacity(MAX_CLIENTS),
             next_update: Instant::now() + *report_interval,
             report_interval: *report_interval,
             output_location,

--- a/src/stats/reporter.rs
+++ b/src/stats/reporter.rs
@@ -19,7 +19,6 @@
 use crate::stats::{ClientStats, StatsQueue, MAX_CLIENTS};
 use chrono::Utc;
 use csv;
-use fixedbitset::FixedBitSet;
 use std::collections::HashMap;
 use std::fs::File;
 use std::net::IpAddr;
@@ -32,7 +31,6 @@ use std::time::{Duration, Instant};
 pub struct Reporter {
     source_queue: Arc<StatsQueue>,
     client_stats: HashMap<IpAddr, ClientStats>,
-    seen_addrs: FixedBitSet,
     next_update: Instant,
     report_interval: Duration,
     output_location: PathBuf,
@@ -48,7 +46,6 @@ impl Reporter {
         Reporter {
             source_queue,
             client_stats: HashMap::with_capacity(MAX_CLIENTS),
-            seen_addrs: FixedBitSet::with_capacity(u32::MAX as usize),
             next_update: Instant::now() + *report_interval,
             report_interval: report_interval.clone(),
             output_location: output_location.to_path_buf(),
@@ -63,7 +60,6 @@ impl Reporter {
                 self.next_update = Instant::now() + self.report_interval;
                 self.report();
                 self.client_stats.clear();
-                self.seen_addrs.clear();
             }
 
             sleep(Duration::from_secs(1));
@@ -76,15 +72,6 @@ impl Reporter {
 
         while let Some(stats) = self.source_queue.pop() {
             for client in stats {
-                match client.ip_addr {
-                    IpAddr::V4(addr) => {
-                        let ip = u32::from(addr);
-                        // SAFETY: above cast to u32 ensures ip is within bitset bounds
-                        unsafe { self.seen_addrs.insert_unchecked(ip as usize); }
-                    }
-                    IpAddr::V6(_) => {} // no-op for now, IPv6 not supported
-                }
-
                 self.client_stats.entry(client.ip_addr)
                     .or_insert_with_key(|ip_addr| { ClientStats::new(ip_addr.clone()) })
                     .merge(&client);
@@ -143,11 +130,6 @@ impl Reporter {
             }
         }
 
-        let popcount = self.seen_addrs.count_ones(0..self.seen_addrs.len());
-
-        info!(
-            "Wrote {} records with {} unique addresses in {:.3} seconds",
-            num_processed, popcount, start.elapsed().as_secs_f32()
-        );
+        info!("Wrote {} records in {:.3} seconds",num_processed, start.elapsed().as_secs_f32());
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -132,7 +132,7 @@ impl Tag {
     }
 
     /// A short (non canonical) string representation of the tag
-    fn to_string(&self) -> String {
+    fn as_string(self) -> String {
         match self {
             Tag::PAD => String::from("PAD"),
             Tag::SIG => String::from("SIG"),
@@ -145,7 +145,7 @@ impl Tag {
 
 impl Display for Tag {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_string())
+        write!(f, "{}", self.as_string())
     }
 }
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -27,18 +27,16 @@ pub enum Tag {
     //
     // Tags are written here in ascending order
     SIG,
-    SRV,
     VER,
-    DUT1,
+    SRV,
     NONC,
     DELE,
     PATH,
-    DTAI,
     RADI,
     PUBK,
-    LEAP,
     MIDP,
     SREP,
+    VERS,
     MINT,
     ROOT,
     CERT,
@@ -66,10 +64,8 @@ impl Tag {
     const BYTES_SIG: &'static [u8] = b"SIG\x00";
     const BYTES_SRV: &'static [u8] = b"SRV\x00";
     const BYTES_SREP: &'static [u8] = b"SREP";
+    const BYTES_VERS: &'static [u8] = b"VERS";
     const BYTES_VER: &'static [u8] = b"VER\x00";
-    const BYTES_DUT1: &'static [u8] = b"DUT1";
-    const BYTES_DTAI: &'static [u8] = b"DTAI";
-    const BYTES_LEAP: &'static [u8] = b"LEAP";
     const BYTES_ZZZZ: &'static [u8] = b"ZZZZ";
 
     /// Translates a tag into its on-the-wire representation
@@ -90,10 +86,8 @@ impl Tag {
             Tag::SIG => Tag::BYTES_SIG,
             Tag::SRV => Tag::BYTES_SRV,
             Tag::SREP => Tag::BYTES_SREP,
+            Tag::VERS => Tag::BYTES_VERS,
             Tag::VER => Tag::BYTES_VER,
-            Tag::DUT1 => Tag::BYTES_DUT1,
-            Tag::DTAI => Tag::BYTES_DTAI,
-            Tag::LEAP => Tag::BYTES_LEAP,
             Tag::ZZZZ => Tag::BYTES_ZZZZ,
         }
     }
@@ -114,13 +108,13 @@ impl Tag {
             Tag::BYTES_PUBK => Ok(Tag::PUBK),
             Tag::BYTES_RADI => Ok(Tag::RADI),
             Tag::BYTES_ROOT => Ok(Tag::ROOT),
-            Tag::BYTES_SIG => Ok(Tag::SIG),
+
             Tag::BYTES_SRV => Ok(Tag::SRV),
+            Tag::BYTES_SIG => Ok(Tag::SIG),
+
+            Tag::BYTES_VERS => Ok(Tag::VERS),
             Tag::BYTES_SREP => Ok(Tag::SREP),
             Tag::BYTES_VER => Ok(Tag::VER),
-            Tag::BYTES_DUT1 => Ok(Tag::DUT1),
-            Tag::BYTES_DTAI => Ok(Tag::DTAI),
-            Tag::BYTES_LEAP => Ok(Tag::LEAP),
             Tag::BYTES_ZZZZ => Ok(Tag::ZZZZ),
             _ => Err(Error::InvalidTag(Box::from(bytes))),
         }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -49,7 +49,7 @@ pub enum Tag {
 }
 
 impl Tag {
-    pub (crate) const HASH_PREFIX_SRV: &'static [u8] = &[0xff];
+    pub(crate) const HASH_PREFIX_SRV: &'static [u8] = &[0xff];
 
     const BYTES_CERT: &'static [u8] = b"CERT";
     const BYTES_DELE: &'static [u8] = b"DELE";

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -88,6 +88,9 @@ impl Tag {
     /// Return the `Tag` corresponding to the on-the-wire representation in `bytes` or an
     /// `Error::InvalidTag` if `bytes` do not correspond to a valid tag.
     pub const fn from_wire(bytes: &[u8]) -> Result<Self, Error> {
+        // Wish we could do something like
+        //     Tag::SIG.data().wire => Ok(Tag::SIG),
+        // to eliminate the duplication
         match bytes {
             b"SIG\x00" => Ok(Tag::SIG),
             b"VER\x00" => Ok(Tag::VER),

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -18,14 +18,13 @@ use std::fmt::{Display, Formatter};
 use crate::error::Error;
 
 /// An unsigned 32-bit value (key) that maps to a byte-string (value).
+///
+/// Tags are ordered by their little-endian encoding of the ASCII tag value.
+/// For example, 'SIG\x00' is 0x00474953 and 'NONC' is 0x434e4f4e.
 #[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Clone, Copy, Sequence)]
 pub enum Tag {
-    // Enforcement of the "tags in strictly increasing order" rule is done using the
-    // little-endian encoding of the ASCII tag value; e.g. 'SIG\x00' is 0x00474953 and
-    // 'NONC' is 0x434e4f4e.
-    //
-    // Tags are written here in ascending order
+    // Tags are listed in ascending order based on their wire representation
     SIG,
     VER,
     SRV,
@@ -46,94 +45,80 @@ pub enum Tag {
     PAD,
 }
 
+/// Metadata for a tag: wire format and display string.
+struct TagData {
+    /// The on-the-wire representation of the tag.
+    wire: &'static [u8],
+    /// The string representation of the tag for display purposes.
+    display: &'static str,
+}
+
 impl Tag {
     pub(crate) const HASH_PREFIX_SRV: &'static [u8] = &[0xff];
 
-    const BYTES_CERT: &'static [u8] = b"CERT";
-    const BYTES_DELE: &'static [u8] = b"DELE";
-    const BYTES_INDX: &'static [u8] = b"INDX";
-    const BYTES_MAXT: &'static [u8] = b"MAXT";
-    const BYTES_MIDP: &'static [u8] = b"MIDP";
-    const BYTES_MINT: &'static [u8] = b"MINT";
-    const BYTES_NONC: &'static [u8] = b"NONC";
-    const BYTES_PAD: &'static [u8] = b"PAD\xff";
-    const BYTES_PATH: &'static [u8] = b"PATH";
-    const BYTES_PUBK: &'static [u8] = b"PUBK";
-    const BYTES_RADI: &'static [u8] = b"RADI";
-    const BYTES_ROOT: &'static [u8] = b"ROOT";
-    const BYTES_SIG: &'static [u8] = b"SIG\x00";
-    const BYTES_SRV: &'static [u8] = b"SRV\x00";
-    const BYTES_SREP: &'static [u8] = b"SREP";
-    const BYTES_VERS: &'static [u8] = b"VERS";
-    const BYTES_VER: &'static [u8] = b"VER\x00";
-    const BYTES_ZZZZ: &'static [u8] = b"ZZZZ";
-
-    /// Translates a tag into its on-the-wire representation
-    pub fn wire_value(self) -> &'static [u8] {
+    /// Returns metadata for this tag.
+    fn data(&self) -> TagData {
         match self {
-            Tag::CERT => Tag::BYTES_CERT,
-            Tag::DELE => Tag::BYTES_DELE,
-            Tag::INDX => Tag::BYTES_INDX,
-            Tag::MAXT => Tag::BYTES_MAXT,
-            Tag::MIDP => Tag::BYTES_MIDP,
-            Tag::MINT => Tag::BYTES_MINT,
-            Tag::NONC => Tag::BYTES_NONC,
-            Tag::PAD => Tag::BYTES_PAD,
-            Tag::PATH => Tag::BYTES_PATH,
-            Tag::PUBK => Tag::BYTES_PUBK,
-            Tag::RADI => Tag::BYTES_RADI,
-            Tag::ROOT => Tag::BYTES_ROOT,
-            Tag::SIG => Tag::BYTES_SIG,
-            Tag::SRV => Tag::BYTES_SRV,
-            Tag::SREP => Tag::BYTES_SREP,
-            Tag::VERS => Tag::BYTES_VERS,
-            Tag::VER => Tag::BYTES_VER,
-            Tag::ZZZZ => Tag::BYTES_ZZZZ,
+            Tag::SIG => TagData { wire: b"SIG\x00", display: "SIG" },
+            Tag::VER => TagData { wire: b"VER\x00", display: "VER" },
+            Tag::SRV => TagData { wire: b"SRV\x00", display: "SRV" },
+            Tag::NONC => TagData { wire: b"NONC", display: "NONC" },
+            Tag::DELE => TagData { wire: b"DELE", display: "DELE" },
+            Tag::PATH => TagData { wire: b"PATH", display: "PATH" },
+            Tag::RADI => TagData { wire: b"RADI", display: "RADI" },
+            Tag::PUBK => TagData { wire: b"PUBK", display: "PUBK" },
+            Tag::MIDP => TagData { wire: b"MIDP", display: "MIDP" },
+            Tag::SREP => TagData { wire: b"SREP", display: "SREP" },
+            Tag::VERS => TagData { wire: b"VERS", display: "VERS" },
+            Tag::MINT => TagData { wire: b"MINT", display: "MINT" },
+            Tag::ROOT => TagData { wire: b"ROOT", display: "ROOT" },
+            Tag::CERT => TagData { wire: b"CERT", display: "CERT" },
+            Tag::MAXT => TagData { wire: b"MAXT", display: "MAXT" },
+            Tag::INDX => TagData { wire: b"INDX", display: "INDX" },
+            Tag::ZZZZ => TagData { wire: b"ZZZZ", display: "ZZZZ" },
+            Tag::PAD => TagData { wire: b"PAD\xff", display: "PAD" },
         }
+    }
+
+    /// Returns the on-the-wire representation of this tag.
+    pub fn wire_value(&self) -> &'static [u8] {
+        self.data().wire
     }
 
     /// Return the `Tag` corresponding to the on-the-wire representation in `bytes` or an
     /// `Error::InvalidTag` if `bytes` do not correspond to a valid tag.
     pub fn from_wire(bytes: &[u8]) -> Result<Self, Error> {
         match bytes {
-            Tag::BYTES_CERT => Ok(Tag::CERT),
-            Tag::BYTES_DELE => Ok(Tag::DELE),
-            Tag::BYTES_INDX => Ok(Tag::INDX),
-            Tag::BYTES_MAXT => Ok(Tag::MAXT),
-            Tag::BYTES_MIDP => Ok(Tag::MIDP),
-            Tag::BYTES_MINT => Ok(Tag::MINT),
-            Tag::BYTES_NONC => Ok(Tag::NONC),
-            Tag::BYTES_PAD => Ok(Tag::PAD),
-            Tag::BYTES_PATH => Ok(Tag::PATH),
-            Tag::BYTES_PUBK => Ok(Tag::PUBK),
-            Tag::BYTES_RADI => Ok(Tag::RADI),
-            Tag::BYTES_ROOT => Ok(Tag::ROOT),
-
-            Tag::BYTES_SRV => Ok(Tag::SRV),
-            Tag::BYTES_SIG => Ok(Tag::SIG),
-
-            Tag::BYTES_VERS => Ok(Tag::VERS),
-            Tag::BYTES_SREP => Ok(Tag::SREP),
-            Tag::BYTES_VER => Ok(Tag::VER),
-            Tag::BYTES_ZZZZ => Ok(Tag::ZZZZ),
+            b"SIG\x00" => Ok(Tag::SIG),
+            b"VER\x00" => Ok(Tag::VER),
+            b"SRV\x00" => Ok(Tag::SRV),
+            b"NONC" => Ok(Tag::NONC),
+            b"DELE" => Ok(Tag::DELE),
+            b"PATH" => Ok(Tag::PATH),
+            b"RADI" => Ok(Tag::RADI),
+            b"PUBK" => Ok(Tag::PUBK),
+            b"MIDP" => Ok(Tag::MIDP),
+            b"SREP" => Ok(Tag::SREP),
+            b"VERS" => Ok(Tag::VERS),
+            b"MINT" => Ok(Tag::MINT),
+            b"ROOT" => Ok(Tag::ROOT),
+            b"CERT" => Ok(Tag::CERT),
+            b"MAXT" => Ok(Tag::MAXT),
+            b"INDX" => Ok(Tag::INDX),
+            b"ZZZZ" => Ok(Tag::ZZZZ),
+            b"PAD\xff" => Ok(Tag::PAD),
             _ => Err(Error::InvalidTag(Box::from(bytes))),
         }
     }
 
-    /// Tags for which values are themselves an `RtMessage`
+    /// Returns true if this tag's value is itself an `RtMessage`.
     pub fn is_nested(&self) -> bool {
-        *self == Tag::CERT || *self == Tag::DELE || *self == Tag::SREP
+        matches!(self, Tag::CERT | Tag::DELE | Tag::SREP)
     }
 
-    /// A short (non canonical) string representation of the tag
-    fn as_string(self) -> String {
-        match self {
-            Tag::PAD => String::from("PAD"),
-            Tag::SIG => String::from("SIG"),
-            Tag::SRV => String::from("SRV"),
-            Tag::VER => String::from("VER"),
-            _ => String::from_utf8(self.wire_value().to_vec()).unwrap(),
-        }
+    /// A short (non-canonical) string representation of the tag
+    fn as_string(&self) -> String {
+        self.data().display.to_string()
     }
 }
 
@@ -151,11 +136,23 @@ mod test {
     #[test]
     fn tags_in_increasing_order() {
         let values = enum_iterator::all::<Tag>().collect::<Vec<_>>();
-        for (idx, _) in values.iter().enumerate() {
-            if idx == 0 {
-                continue;
-            }
-            assert!(values[idx - 1] < values[idx]);
+
+        // Start from index 1 and compare with the previous element
+        for i in 1..values.len() {
+            assert!(
+                values[i-1] < values[i],
+                "Tags not in ascending order: {:?} >= {:?}", values[i-1], values[i]
+            );
+        }
+    }
+
+    #[test]
+    fn test_wire_value_and_from_wire() {
+        // Test that for each tag, from_wire(wire_value()) is identity
+        for tag in enum_iterator::all::<Tag>() {
+            let wire = tag.wire_value();
+            let roundtrip = Tag::from_wire(wire).unwrap();
+            assert_eq!(tag, roundtrip);
         }
     }
 }

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -57,7 +57,7 @@ impl Tag {
     pub(crate) const HASH_PREFIX_SRV: &'static [u8] = &[0xff];
 
     /// Returns metadata for this tag.
-    fn data(&self) -> TagData {
+    const fn data(&self) -> TagData {
         match self {
             Tag::SIG => TagData { wire: b"SIG\x00", display: "SIG" },
             Tag::VER => TagData { wire: b"VER\x00", display: "VER" },
@@ -81,13 +81,13 @@ impl Tag {
     }
 
     /// Returns the on-the-wire representation of this tag.
-    pub fn wire_value(&self) -> &'static [u8] {
+    pub const fn wire_value(&self) -> &'static [u8] {
         self.data().wire
     }
 
     /// Return the `Tag` corresponding to the on-the-wire representation in `bytes` or an
     /// `Error::InvalidTag` if `bytes` do not correspond to a valid tag.
-    pub fn from_wire(bytes: &[u8]) -> Result<Self, Error> {
+    pub const fn from_wire(bytes: &[u8]) -> Result<Self, Error> {
         match bytes {
             b"SIG\x00" => Ok(Tag::SIG),
             b"VER\x00" => Ok(Tag::VER),
@@ -107,18 +107,21 @@ impl Tag {
             b"INDX" => Ok(Tag::INDX),
             b"ZZZZ" => Ok(Tag::ZZZZ),
             b"PAD\xff" => Ok(Tag::PAD),
-            _ => Err(Error::InvalidTag(Box::from(bytes))),
+            _ => Err(Error::InvalidTag),
         }
     }
 
     /// Returns true if this tag's value is itself an `RtMessage`.
-    pub fn is_nested(&self) -> bool {
-        matches!(self, Tag::CERT | Tag::DELE | Tag::SREP)
+    pub const fn is_nested(&self) -> bool {
+        match self {
+            Tag::CERT | Tag::DELE | Tag::SREP => true,
+            _ => false,
+        }
     }
 
     /// A short (non-canonical) string representation of the tag
-    fn as_string(&self) -> String {
-        self.data().display.to_string()
+    pub const fn as_string(&self) -> &'static str {
+        self.data().display
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -28,16 +28,16 @@ pub enum Version {
 }
 
 // Google classic (unused)
-const BYTES_VER_CLASSIC: &'static [u8] = &[0x00, 0x00, 0x00, 0x00];
-const STR_VER_CLASSIC: &'static str = "Classic";
+const BYTES_VER_CLASSIC: &[u8] = &[0x00, 0x00, 0x00, 0x00];
+const STR_VER_CLASSIC: &str = "Classic";
 
 // RFC version 1
-const BYTES_VER_RFC: &'static [u8] = &[0x01, 0x00, 0x00, 0x00];
-const STR_VER_RFC: &'static str = "Rfc";
+const BYTES_VER_RFC: &[u8] = &[0x01, 0x00, 0x00, 0x00];
+const STR_VER_RFC: &str = "Rfc";
 
 // RFC draft 11 (keep updated as draft evolves)
-const BYTES_VER_RFC_DRAFT11: &'static [u8] = &[0x0b, 0x00, 0x00, 0x80];
-const STR_VER_RFC_DRAFT11: &'static str = "RfcDraft11";
+const BYTES_VER_RFC_DRAFT11: &[u8] = &[0x0b, 0x00, 0x00, 0x80];
+const STR_VER_RFC_DRAFT11: &str = "RfcDraft11";
 
 impl Version {
     /// On-the-wire representation of the version value

--- a/src/version.rs
+++ b/src/version.rs
@@ -39,6 +39,10 @@ const STR_VER_RFC: &str = "Rfc";
 const BYTES_VER_RFC_DRAFT12: &[u8] = &[0x0c, 0x00, 0x00, 0x80];
 const STR_VER_RFC_DRAFT12: &str = "RfcDraft12";
 
+// Ordered (ascending) list of supported versions (VERS tag value)
+pub(crate) const BYTES_SUPPORTED_VERSIONS: &[&[u8]] =
+    &[Version::Classic.wire_bytes(), Version::Rfc.wire_bytes(), Version::RfcDraft12.wire_bytes()];
+
 impl Version {
     /// On-the-wire representation of the version value
     pub const fn wire_bytes(self) -> &'static [u8] {

--- a/src/version.rs
+++ b/src/version.rs
@@ -18,10 +18,10 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Clone, Copy)]
 pub enum Version {
     /// Original Google version from https://roughtime.googlesource.com/roughtime/+/HEAD/PROTOCOL.md
-    Classic,
+    Google,
 
-    /// IETF draft version 12 (placeholder for final IETF standardized version)
-    RfcDraft12,
+    /// IETF draft version 13 (placeholder for final IETF standardized version)
+    RfcDraft13,
 }
 
 struct VersionData {
@@ -34,15 +34,15 @@ struct VersionData {
 impl Version {
     const fn data(&self) -> VersionData {
         match self {
-            Version::Classic => VersionData {
+            Version::Google => VersionData {
                 wire: &[0x00, 0x00, 0x00, 0x00],
-                display: "Classic",
+                display: "Google",
                 dele_prefix: b"RoughTime v1 delegation signature--\x00",
                 srep_prefix: b"RoughTime v1 response signature\x00",
             },
-            Version::RfcDraft12 => VersionData {
+            Version::RfcDraft13 => VersionData {
                 wire: &[0x0c, 0x00, 0x00, 0x80],
-                display: "RfcDraft12",
+                display: "RfcDraft13",
                 dele_prefix: b"RoughTime v1 delegation signature\x00",
                 srep_prefix: b"RoughTime v1 response signature\x00",
             },
@@ -52,8 +52,8 @@ impl Version {
     /// Ordered (ascending) on-the-wire bytes of supported versions (`VERS` tag value)
     pub fn supported_versions_wire() -> Vec<u8> {
         [
-            Version::Classic.wire_bytes(),
-            Version::RfcDraft12.wire_bytes(),
+            Version::Google.wire_bytes(),
+            Version::RfcDraft13.wire_bytes(),
         ]
         .concat()
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -20,51 +20,69 @@ pub enum Version {
     /// Original Google version from https://roughtime.googlesource.com/roughtime/+/HEAD/PROTOCOL.md
     Classic,
 
-    /// Placeholder for final IETF standardized version
-    Rfc,
-
-    /// IETF draft version 12
+    /// IETF draft version 12 (placeholder for final IETF standardized version)
     RfcDraft12,
 }
 
-// Google classic (unused)
-const BYTES_VER_CLASSIC: &[u8] = &[0x00, 0x00, 0x00, 0x00];
-const STR_VER_CLASSIC: &str = "Classic";
-
-// RFC version 1
-const BYTES_VER_RFC: &[u8] = &[0x01, 0x00, 0x00, 0x00];
-const STR_VER_RFC: &str = "Rfc";
-
-// RFC draft 12 (keep updated as draft evolves)
-const BYTES_VER_RFC_DRAFT12: &[u8] = &[0x0c, 0x00, 0x00, 0x80];
-const STR_VER_RFC_DRAFT12: &str = "RfcDraft12";
-
-// Ordered (ascending) list of supported versions (VERS tag value)
-pub(crate) const BYTES_SUPPORTED_VERSIONS: &[&[u8]] =
-    &[Version::Classic.wire_bytes(), Version::Rfc.wire_bytes(), Version::RfcDraft12.wire_bytes()];
+struct VersionData {
+    wire: &'static [u8],
+    display: &'static str,
+    dele_prefix: &'static [u8],
+    srep_prefix: &'static [u8],
+}
 
 impl Version {
-    /// On-the-wire representation of the version value
-    pub const fn wire_bytes(self) -> &'static [u8] {
+    const fn data(&self) -> VersionData {
         match self {
-            Version::Classic => BYTES_VER_CLASSIC,
-            Version::Rfc => BYTES_VER_RFC,
-            Version::RfcDraft12 => BYTES_VER_RFC_DRAFT12,
+            Version::Classic => VersionData {
+                wire: &[0x00, 0x00, 0x00, 0x00],
+                display: "Classic",
+                dele_prefix: b"RoughTime v1 delegation signature--\x00",
+                srep_prefix: b"RoughTime v1 response signature\x00",
+            },
+            Version::RfcDraft12 => VersionData {
+                wire: &[0x0c, 0x00, 0x00, 0x80],
+                display: "RfcDraft12",
+                dele_prefix: b"RoughTime v1 delegation signature\x00",
+                srep_prefix: b"RoughTime v1 response signature\x00",
+            },
         }
     }
 
+    /// Ordered (ascending) on-the-wire bytes of supported versions (`VERS` tag value)
+    pub fn supported_versions_wire() -> Vec<u8> {
+        [
+            Version::Classic.wire_bytes(),
+            Version::RfcDraft12.wire_bytes(),
+        ]
+        .concat()
+    }
+
+    /// On-the-wire representation of the `Version`
+    pub const fn wire_bytes(&self) -> &'static [u8] {
+        self.data().wire
+    }
+
     /// A short (non-canonical) string representation of the `Version`
-    pub const fn to_string(&self) -> &'static str {
-        match self {
-            Version::Classic => STR_VER_CLASSIC,
-            Version::Rfc => STR_VER_RFC,
-            Version::RfcDraft12 => STR_VER_RFC_DRAFT12,
-        }
+    pub const fn as_string(&self) -> &'static str {
+        self.data().display
+    }
+
+    /// Domain separator prefixed to the server's `DELE` value before generating or
+    /// verifying the signature
+    pub const fn dele_prefix(&self) -> &'static [u8] {
+        self.data().dele_prefix
+    }
+
+    /// Domain separator prefixed to the server's `SREP` value before generating or
+    /// verifying the signature
+    pub const fn sign_prefix(&self) -> &'static [u8] {
+        self.data().srep_prefix
     }
 }
 
 impl Display for Version {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_string())
+        write!(f, "{}", self.as_string())
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -23,8 +23,8 @@ pub enum Version {
     /// Placeholder for final IETF standardized version
     Rfc,
 
-    /// IETF draft version 11
-    RfcDraft11,
+    /// IETF draft version 12
+    RfcDraft12,
 }
 
 // Google classic (unused)
@@ -35,9 +35,9 @@ const STR_VER_CLASSIC: &str = "Classic";
 const BYTES_VER_RFC: &[u8] = &[0x01, 0x00, 0x00, 0x00];
 const STR_VER_RFC: &str = "Rfc";
 
-// RFC draft 11 (keep updated as draft evolves)
-const BYTES_VER_RFC_DRAFT11: &[u8] = &[0x0b, 0x00, 0x00, 0x80];
-const STR_VER_RFC_DRAFT11: &str = "RfcDraft11";
+// RFC draft 12 (keep updated as draft evolves)
+const BYTES_VER_RFC_DRAFT12: &[u8] = &[0x0c, 0x00, 0x00, 0x80];
+const STR_VER_RFC_DRAFT12: &str = "RfcDraft12";
 
 impl Version {
     /// On-the-wire representation of the version value
@@ -45,7 +45,7 @@ impl Version {
         match self {
             Version::Classic => BYTES_VER_CLASSIC,
             Version::Rfc => BYTES_VER_RFC,
-            Version::RfcDraft11 => BYTES_VER_RFC_DRAFT11,
+            Version::RfcDraft12 => BYTES_VER_RFC_DRAFT12,
         }
     }
 
@@ -54,7 +54,7 @@ impl Version {
         match self {
             Version::Classic => STR_VER_CLASSIC,
             Version::Rfc => STR_VER_RFC,
-            Version::RfcDraft11 => STR_VER_RFC_DRAFT11,
+            Version::RfcDraft12 => STR_VER_RFC_DRAFT12,
         }
     }
 }


### PR DESCRIPTION
Updates to comply with RFC draft13. (#46)

* Numerous code cleanups
* Hash over the entire request packet in Merkle tree
* Check depth of PATH is <32
* Remove trailing "--" from delegation signature context string
* Sorted values in `VER` tag
* Version number changed to `0x8000000c`
* `VER` tag moved inside `SREP`
* Added `VERS` tag