### PR TITLE
Address review feedback on allocation-free signing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,6 +128,29 @@ jobs:
       - name: Check feature combination
         run: cargo check -p roughenough-keys --all-targets ${{ matrix.features }}
 
+  # roughenough-keys depends on aws-lc-sys directly (allocation-free Ed25519
+  # FFI) and its version must match what aws-lc-rs requires. Skew does not
+  # fail the build: aws-lc-sys version-mangles its symbols and links key, so
+  # two AWS-LC copies would link silently.
+  duplicate-aws-lc-sys:
+    name: Duplicate aws-lc-sys Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Check for duplicate aws-lc-sys versions
+        run: |
+          if cargo tree --workspace --all-features --duplicates | grep aws-lc-sys; then
+            echo "error: multiple aws-lc-sys versions resolved; align the" \
+                 "workspace aws-lc-sys pin with the version aws-lc-rs requires"
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ roughenough-reporting-server = { path = "crates/roughenough-reporting-server", v
 # External dependencies
 aws-config = { version = "1.9", default-features = false, features = ["default-https-client", "rt-tokio", "credentials-process"] }
 aws-lc-rs = { version = "1.17", default-features = false, features = ["aws-lc-sys", "alloc"] }
+# Keep in lockstep with the aws-lc-sys version aws-lc-rs requires: aws-lc-sys
+# version-mangles its symbols and links key, so skew does not fail the build,
+# it silently links two copies of AWS-LC (CI checks cargo tree --duplicates).
 aws-lc-sys = { version = "0.42", default-features = false }
 aws-sdk-kms = { version = "1.112", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-secretsmanager = { version = "1.109", default-features = false, features = ["default-https-client", "rt-tokio"] }

--- a/crates/roughenough-keys/src/online/aws_lc_ed25519.rs
+++ b/crates/roughenough-keys/src/online/aws_lc_ed25519.rs
@@ -1,7 +1,9 @@
-//! This is an audited safe wrapper around aws-lc-sys Ed25519.
+//! Minimal safe wrapper around aws-lc-sys Ed25519 signing.
 //!
-//! The safe aws-lc-rs Ed25519 API makes two allocations per signature. This wrapper uses
-//! aws-lc-sys directly to avoid allocations entirely.
+//! The safe aws-lc-rs Ed25519 API heap-allocates twice per signature: a Rust-side
+//! Vec holding the signature, and a C-side EVP_PKEY_CTX inside EVP_DigestSignInit
+//! (only the Vec is visible to Rust's global allocator). AWS-LC's raw Ed25519
+//! functions are stack-only, so calling them directly keeps signing allocation-free.
 
 use zeroize::Zeroizing;
 
@@ -17,7 +19,7 @@ pub(super) struct KeyPair {
 
 #[allow(
     unsafe_code,
-    reason = "audited safe wrapper around aws-lc-sys's Ed25519"
+    reason = "FFI into AWS-LC; invariants documented at the call site"
 )]
 pub(super) fn keypair_from_seed(seed: &[u8; SEED_LEN]) -> KeyPair {
     let mut public_key = [0; PUBLIC_KEY_LEN];
@@ -41,7 +43,7 @@ pub(super) fn keypair_from_seed(seed: &[u8; SEED_LEN]) -> KeyPair {
 
 #[allow(
     unsafe_code,
-    reason = "audited safe wrapper around aws-lc-sys's Ed25519"
+    reason = "FFI into AWS-LC; invariants documented at the call site"
 )]
 pub(super) fn sign(
     private_key: &[u8; PRIVATE_KEY_LEN],

--- a/crates/roughenough-keys/src/online/onlinekey.rs
+++ b/crates/roughenough-keys/src/online/onlinekey.rs
@@ -133,8 +133,7 @@ impl OnlineKey {
 }
 
 pub(crate) struct OnlineSigner {
-    private_key: Zeroizing<[u8; aws_lc_ed25519::PRIVATE_KEY_LEN]>,
-    public_key: [u8; aws_lc_ed25519::PUBLIC_KEY_LEN],
+    key_pair: aws_lc_ed25519::KeyPair,
 }
 
 impl OnlineSigner {
@@ -146,10 +145,8 @@ impl OnlineSigner {
     }
 
     fn from_seed(seed: &[u8; aws_lc_ed25519::SEED_LEN]) -> OnlineSigner {
-        let key_pair = aws_lc_ed25519::keypair_from_seed(seed);
         OnlineSigner {
-            private_key: key_pair.private_key,
-            public_key: key_pair.public_key,
+            key_pair: aws_lc_ed25519::keypair_from_seed(seed),
         }
     }
 
@@ -158,12 +155,12 @@ impl OnlineSigner {
     }
 
     pub(crate) fn public_key_bytes(&self) -> [u8; 32] {
-        self.public_key
+        self.key_pair.public_key
     }
 
     /// Signs the provided data using the private key associated with this Signer.
     pub(crate) fn sign(&self, data: &[u8]) -> [u8; 64] {
-        aws_lc_ed25519::sign(&self.private_key, data).expect("Ed25519 signing failed")
+        aws_lc_ed25519::sign(&self.key_pair.private_key, data).expect("Ed25519 signing failed")
     }
 }
 
@@ -193,6 +190,24 @@ mod tests {
 
         assert_eq!(signer.public_key_bytes(), expected_public_key);
         assert_eq!(signer.sign(b""), expected_signature);
+    }
+
+    // Vector 1 signs the empty message; this one exercises the FFI message
+    // pointer/length path with actual data
+    #[test]
+    fn rfc8032_test_vector_3() {
+        let seed = decode_hex("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7");
+        let expected_public_key =
+            decode_hex("fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025");
+        let expected_signature = decode_hex(
+            "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac\
+             18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a",
+        );
+
+        let signer = OnlineSigner::from_seed(&seed);
+
+        assert_eq!(signer.public_key_bytes(), expected_public_key);
+        assert_eq!(signer.sign(&[0xaf, 0x82]), expected_signature);
     }
 
     #[test]


### PR DESCRIPTION
- Guard against silent aws-lc-sys version skew: lockstep comment in Cargo.toml and a CI job failing on duplicate aws-lc-sys versions
- Replace 'audited' wording
- Add comment on heap allocations the FFI wrapper avoids
- Add RFC 8032 test vector 3 to exercise a non-empty message
- Store the wrapper KeyPair directly in OnlineSigner