### PR TITLE
Bump aws-lc-sys pin to 0.43 to match aws-lc-rs 1.17.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,21 +152,8 @@ version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
- "aws-lc-sys 0.43.0",
+ "aws-lc-sys",
  "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
 ]
 
 [[package]]
@@ -2605,7 +2592,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2941,7 +2928,7 @@ version = "2.0.0"
 dependencies = [
  "aws-config",
  "aws-lc-rs",
- "aws-lc-sys 0.42.0",
+ "aws-lc-sys",
  "aws-sdk-kms",
  "aws-sdk-secretsmanager",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ aws-lc-rs = { version = "1.17", default-features = false, features = ["aws-lc-sy
 # Keep in lockstep with the aws-lc-sys version aws-lc-rs requires: aws-lc-sys
 # version-mangles its symbols and links key, so skew does not fail the build,
 # it silently links two copies of AWS-LC (CI checks cargo tree --duplicates).
-aws-lc-sys = { version = "0.42", default-features = false }
+aws-lc-sys = { version = "0.43", default-features = false }
 aws-sdk-kms = { version = "1.112", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-secretsmanager = { version = "1.109", default-features = false, features = ["default-https-client", "rt-tokio"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }


### PR DESCRIPTION
aws-lc-rs 1.17.3 requires aws-lc-sys 0.43, but the workspace pinned the direct aws-lc-sys dependency (used by roughenough-keys for Ed25519 FFI) at 0.42. The skew silently compiled and linked two copies of AWS-LC, since aws-lc-sys version-mangles its symbols and links key.

This unifies on aws-lc-sys 0.43.0 so only one copy is built. `cargo tree --workspace --duplicates` no longer reports aws-lc-sys; the remaining syn 2/3 duplication is proc-macro build-time only and resolves upstream as the ecosystem migrates to syn 3.

Verified: cargo check --workspace, cargo test, clippy, and fmt all clean.