### PR TITLE
Add explicit least-privilege permissions to CI workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
@@ -214,8 +217,6 @@ jobs:
 
   build-artifacts:
     name: Build Release Artifacts
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
Fixes the nine open code scanning alerts (actions/missing-workflow-permissions) on rust.yml, docs.yml, and examples.yml. 